### PR TITLE
feat(settings): complete Advanced Compose migration; flip to default

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -10,12 +10,18 @@ Each non-Compose screen has a `*Controller` (Conductor, view) + `*Presenter` (bu
 
 ## Settings UI — two-screen pattern
 
-Every settings section has two parallel implementations:
+A settings section under migration has two parallel implementations:
 
-- **Legacy Conductor controller** in `app/.../ui/setting/controllers/legacy/` — **what users see by default**.
-- **Compose screen** in `app/.../yokai/presentation/settings/screen/` — experimental, not yet the default.
+- **Compose screen** in `app/.../yokai/presentation/settings/screen/` — the target stack.
+- **Legacy Conductor controller** in `app/.../ui/setting/controllers/legacy/` — kept as a long-press fallback during the soak period after the section flips to Compose-default.
 
-**When adding or editing settings UI, changes go to the legacy controller.** The Compose screen is invisible to users until that section's migration is complete. Advanced settings specifically: normal tap → legacy; long-press → Compose (experimental).
+**Flipped (Compose-default):** Security, Data and storage, Advanced. Tap reaches Compose; long-press toasts and falls back to legacy.
+
+**Not flipped:** General, Appearance, Library, Reader, Downloads, Browse, Tracking, About — legacy only.
+
+**When adding or editing UI for a flipped section**, changes go to the Compose screen. The legacy controller stays alive (still indexed by `SettingsSearchHelper`) — don't delete it without solving Compose-side search.
+
+**When adding or editing UI for a not-yet-flipped section**, changes go to the legacy controller. The Compose screen, if any, is invisible to users until the section is migrated and flipped.
 
 ## Preferences
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is simplified version of [Keep a Changelog](https://keepachangelog.co
 
 ### Changes
 - Settings → Security rebuilt on the new Compose pattern. Long-press the row to reach the legacy version
-- Settings → Advanced now opens the Compose version by default. Tap reaches the modern screen; long-press still falls back to the legacy preferences screen during the soak period. The Compose version is now feature-complete: cleanup-downloaded-chapters and revoke-all-extensions are wired up, the Reader category (hardware bitmap threshold, color profile picker, reader debug mode) is back, the external local-source switch is back, and the developer dev/debug-only "Crash the app!" and "Prune finished workers" actions are available
+- Settings → Advanced rebuilt on the new Compose pattern. Long-press the row to reach the legacy version. Cleanup downloaded chapters, revoke trust for all extensions, the Reader options (hardware bitmap threshold, color profile picker, reader debug mode), and the external local-source toggle are all back; debug builds keep the "Crash the app!" and "Prune finished workers" actions
 
 ### Fixes
 - Opening the search bar in Settings no longer crashes the app. The experimental "Change App Icon" dropdown was sharing a SharedPreferences key with the Compose-library toggle, causing a `ClassCastException` when search enumerated every settings screen at once

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is simplified version of [Keep a Changelog](https://keepachangelog.co
 
 ### Changes
 - Settings → Security rebuilt on the new Compose pattern. Long-press the row to reach the legacy version
-- Settings → Advanced (Compose version, reached via long-press) is now feature-complete with its legacy counterpart. The cleanup-downloaded-chapters and revoke-all-extensions actions now work, the Reader category (hardware bitmap threshold, color profile picker, reader debug mode) is wired up, the external local-source switch is back, and the developer dev/debug-only "Crash the app!" and "Prune finished workers" actions are available
+- Settings → Advanced now opens the Compose version by default. Tap reaches the modern screen; long-press still falls back to the legacy preferences screen during the soak period. The Compose version is now feature-complete: cleanup-downloaded-chapters and revoke-all-extensions are wired up, the Reader category (hardware bitmap threshold, color profile picker, reader debug mode) is back, the external local-source switch is back, and the developer dev/debug-only "Crash the app!" and "Prune finished workers" actions are available
 
 ### Fixes
 - Opening the search bar in Settings no longer crashes the app. The experimental "Change App Icon" dropdown was sharing a SharedPreferences key with the Compose-library toggle, causing a `ClassCastException` when search enumerated every settings screen at once

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is simplified version of [Keep a Changelog](https://keepachangelog.co
 
 ### Changes
 - Settings → Security rebuilt on the new Compose pattern. Long-press the row to reach the legacy version
+- Settings → Advanced (Compose version, reached via long-press) is now feature-complete with its legacy counterpart. The cleanup-downloaded-chapters and revoke-all-extensions actions now work, the Reader category (hardware bitmap threshold, color profile picker, reader debug mode) is wired up, the external local-source switch is back, and the developer dev/debug-only "Crash the app!" and "Prune finished workers" actions are available
 
 ### Fixes
 - Opening the search bar in Settings no longer crashes the app. The experimental "Change App Icon" dropdown was sharing a SharedPreferences key with the Compose-library toggle, causing a `ClassCastException` when search enumerated every settings screen at once

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/controllers/SettingsMainController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/controllers/SettingsMainController.kt
@@ -110,10 +110,10 @@ class SettingsMainController : SettingsLegacyController(), FloatingSearchInterfa
             iconRes = R.drawable.ic_code_24dp
             iconTint = tintColor
             titleRes = MR.strings.advanced
-            onClick { navigateTo(SettingsAdvancedLegacyController()) }
+            onClick { navigateTo(SettingsAdvancedController()) }
             onLongClick {
-                navigateTo(SettingsAdvancedController())
-                context.toast("You're entering experimental version of 'Advanced'")
+                navigateTo(SettingsAdvancedLegacyController())
+                context.toast("You're entering legacy version of 'Advanced'")
             }
         }
         preference {

--- a/app/src/main/java/yokai/presentation/settings/screen/SettingsAdvancedScreen.kt
+++ b/app/src/main/java/yokai/presentation/settings/screen/SettingsAdvancedScreen.kt
@@ -7,18 +7,23 @@ import android.os.PowerManager
 import android.provider.Settings
 import android.webkit.WebStorage
 import android.webkit.WebView
+import android.widget.Toast
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.platform.LocalContext
 import androidx.core.net.toUri
 import cafe.adriel.voyager.navigator.LocalNavigator
 import co.touchlab.kermit.Logger
+import com.hippo.unifile.UniFile
 import dev.icerock.moko.resources.StringResource
 import dev.icerock.moko.resources.compose.stringResource
 import eu.kanade.tachiyomi.BuildConfig
 import eu.kanade.tachiyomi.core.storage.preference.collectAsState
 import eu.kanade.tachiyomi.data.download.DownloadManager
+import eu.kanade.tachiyomi.data.download.DownloadProvider
 import eu.kanade.tachiyomi.data.library.LibraryUpdateJob
 import eu.kanade.tachiyomi.data.preference.PreferencesHelper
 import eu.kanade.tachiyomi.extension.installer.ShizukuInstaller
@@ -36,35 +41,57 @@ import eu.kanade.tachiyomi.network.PREF_DOH_NJALLA
 import eu.kanade.tachiyomi.network.PREF_DOH_QUAD101
 import eu.kanade.tachiyomi.network.PREF_DOH_QUAD9
 import eu.kanade.tachiyomi.network.PREF_DOH_SHECAN
+import eu.kanade.tachiyomi.source.SourceManager
+import eu.kanade.tachiyomi.ui.main.MainActivity
 import eu.kanade.tachiyomi.ui.setting.controllers.database.ClearDatabaseController
 import eu.kanade.tachiyomi.ui.setting.controllers.debug.DebugController
 import eu.kanade.tachiyomi.util.CrashLogUtil
 import eu.kanade.tachiyomi.util.compose.LocalDialogHostState
 import eu.kanade.tachiyomi.util.compose.LocalRouter
 import eu.kanade.tachiyomi.util.compose.currentOrThrow
+import eu.kanade.tachiyomi.util.system.GLUtil
+import eu.kanade.tachiyomi.util.system.ImageUtil
 import eu.kanade.tachiyomi.util.system.isPackageInstalled
 import eu.kanade.tachiyomi.util.system.launchIO
+import eu.kanade.tachiyomi.util.system.launchUI
 import eu.kanade.tachiyomi.util.system.localeContext
 import eu.kanade.tachiyomi.util.system.openInBrowser
 import eu.kanade.tachiyomi.util.system.setDefaultSettings
 import eu.kanade.tachiyomi.util.system.toast
+import eu.kanade.tachiyomi.util.system.workManager
 import eu.kanade.tachiyomi.util.view.withFadeTransaction
 import java.io.File
 import java.net.URI
 import kotlinx.collections.immutable.toImmutableMap
 import kotlinx.collections.immutable.toPersistentList
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import okhttp3.Headers
 import rikka.sui.Sui
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
 import uy.kohesive.injekt.injectLazy
 import yokai.domain.base.BasePreferences
+import yokai.domain.chapter.interactor.GetChapter
+import yokai.domain.extension.interactor.TrustExtension
+import yokai.domain.manga.interactor.GetManga
 import yokai.domain.simple
+import yokai.domain.source.SourcePreferences
+import yokai.domain.ui.settings.ReaderPreferences
 import yokai.i18n.MR
+import yokai.util.lang.getString
 import yokai.presentation.component.preference.Preference
 import yokai.presentation.settings.ComposableSettings
 import yokai.presentation.settings.screen.advanced.StoryBookScreen
+import yokai.presentation.settings.screen.advanced.awaitCleanupDownloadedChapters
 
 object SettingsAdvancedScreen : ComposableSettings() {
+
+    private const val LOG_TAG = "SettingsAdvancedScreen"
 
     private fun readResolve() = SettingsAdvancedScreen
 
@@ -77,6 +104,10 @@ object SettingsAdvancedScreen : ComposableSettings() {
         val basePreferences: BasePreferences by injectLazy()
         val networkPreferences: NetworkPreferences by injectLazy()
         val isUpdaterEnabled = BuildConfig.INCLUDE_UPDATER
+
+        LaunchedEffect(Unit) {
+            Logger.i(LOG_TAG) { "entered compose advanced settings" }
+        }
 
         return buildList {
             add(Preference.PreferenceItem.SwitchPreference(
@@ -99,6 +130,8 @@ object SettingsAdvancedScreen : ComposableSettings() {
             add(getNetworkGroup(networkPreferences))
             add(getExtensionGroup(basePreferences))
             add(getLibraryGroup(basePreferences))
+            add(getReaderGroup(basePreferences))
+            add(getLocalSourceGroup())
             add(getDeveloperGroup())
         }.toPersistentList()
     }
@@ -204,20 +237,41 @@ object SettingsAdvancedScreen : ComposableSettings() {
         // FIXME: Maybe this should be moved to Data and storage?
         val context = LocalContext.current
         val router = LocalRouter.currentOrThrow
+        val scope = rememberCoroutineScope()
+        val alertDialog = LocalDialogHostState.currentOrThrow
 
         val downloadManager: DownloadManager by injectLazy()
+        val getChapter: GetChapter by injectLazy()
+        val getManga: GetManga by injectLazy()
 
         val children = buildList {
             add(Preference.PreferenceItem.TextPreference(
                 title = stringResource(MR.strings.force_download_cache_refresh),
                 subtitle = stringResource(MR.strings.force_download_cache_refresh_summary),
-                onClick = { downloadManager.refreshCache() },
+                onClick = {
+                    Logger.i(LOG_TAG) { "force download cache refresh" }
+                    downloadManager.refreshCache()
+                },
             ))
             add(Preference.PreferenceItem.TextPreference(
                 title = stringResource(MR.strings.clean_up_downloaded_chapters),
                 subtitle = stringResource(MR.strings.delete_unused_chapters),
                 onClick = {
-                    // TODO:
+                    Logger.i(LOG_TAG) { "clean up downloaded chapters clicked" }
+                    scope.launch {
+                        val opts = alertDialog.awaitCleanupDownloadedChapters() ?: return@launch
+                        Logger.i(LOG_TAG) {
+                            "cleanup options → deleteRead=${opts.deleteRead}, deleteNonFavorite=${opts.deleteNonFavorite}"
+                        }
+                        cleanupDownloads(
+                            context = context,
+                            downloadManager = downloadManager,
+                            getChapter = getChapter,
+                            getManga = getManga,
+                            removeRead = opts.deleteRead,
+                            removeNonFavorite = opts.deleteNonFavorite,
+                        )
+                    }
                 },
             ))
             add(Preference.PreferenceItem.TextPreference(
@@ -251,6 +305,54 @@ object SettingsAdvancedScreen : ComposableSettings() {
         } catch (e: Throwable) {
             Logger.e(e) { "Unable to delete WebView data" }
             toast(MR.strings.cache_delete_error)
+        }
+    }
+
+    @Volatile private var cleanupJob: Job? = null
+
+    @OptIn(DelicateCoroutinesApi::class)
+    private fun cleanupDownloads(
+        context: Context,
+        downloadManager: DownloadManager,
+        getChapter: GetChapter,
+        getManga: GetManga,
+        removeRead: Boolean,
+        removeNonFavorite: Boolean,
+    ) {
+        if (cleanupJob?.isActive == true) return
+        context.toast(MR.strings.starting_cleanup)
+        cleanupJob = GlobalScope.launch(Dispatchers.IO, CoroutineStart.DEFAULT) {
+            val mangaList = getManga.awaitAll()
+            val sourceManager: SourceManager = Injekt.get()
+            val downloadProvider = DownloadProvider(context)
+            var foldersCleared = 0
+            val sources = sourceManager.getOnlineSources()
+
+            for (source in sources) {
+                val mangaFolders = downloadManager.getMangaFolders(source)
+                val sourceManga = mangaList.filter { it.source == source.id }
+
+                for (mangaFolder in mangaFolders) {
+                    val manga = sourceManga.find { downloadProvider.getMangaDirName(it) == mangaFolder.name }
+                    if (manga == null) {
+                        if (removeNonFavorite) {
+                            foldersCleared += 1 + (mangaFolder.listFiles()?.size ?: 0)
+                            mangaFolder.delete()
+                        }
+                        continue
+                    }
+                    val chapterList = getChapter.awaitAll(manga, false)
+                    foldersCleared += downloadManager.cleanupChapters(chapterList, manga, source, removeRead, removeNonFavorite)
+                }
+            }
+            launchUI {
+                val cleanupString = if (foldersCleared == 0) {
+                    context.getString(MR.strings.no_folders_to_cleanup)
+                } else {
+                    context.getString(MR.plurals.cleanup_done, foldersCleared, foldersCleared)
+                }
+                context.toast(cleanupString, Toast.LENGTH_LONG)
+            }
         }
     }
 
@@ -349,6 +451,7 @@ object SettingsAdvancedScreen : ComposableSettings() {
         val scope = rememberCoroutineScope()
         val context = LocalContext.current
         val alertDialog = LocalDialogHostState.currentOrThrow
+        val trustExtension: TrustExtension by injectLazy()
         val installerPref by basePreferences.extensionInstaller().collectAsState()
 
 
@@ -399,7 +502,16 @@ object SettingsAdvancedScreen : ComposableSettings() {
             add(Preference.PreferenceItem.TextPreference(
                 title = stringResource(MR.strings.action_revoke_all_extensions),
                 onClick = {
-                    // TODO:
+                    Logger.i(LOG_TAG) { "revoke all extensions clicked" }
+                    scope.launch {
+                        alertDialog.simple {
+                            titleRes = MR.strings.confirm_revoke_all_extensions
+                            onConfirm = {
+                                trustExtension.revokeAll()
+                                context.toast(MR.strings.requires_app_restart)
+                            }
+                        }
+                    }
                 },
             ))
         }.toPersistentList()
@@ -441,14 +553,133 @@ object SettingsAdvancedScreen : ComposableSettings() {
     }
 
     @Composable
+    private fun getReaderGroup(basePreferences: BasePreferences): Preference.PreferenceGroup {
+        val readerPreferences: ReaderPreferences by injectLazy()
+        val context = LocalContext.current
+        val displayProfilePath by basePreferences.displayProfile().collectAsState()
+        val displayProfileSubtitle = remember(displayProfilePath) {
+            if (displayProfilePath.isEmpty()) {
+                null
+            } else {
+                UniFile.fromUri(context, displayProfilePath.toUri())?.filePath ?: displayProfilePath
+            }
+        }
+
+        val children = buildList {
+            if (!ImageUtil.HARDWARE_BITMAP_UNSUPPORTED && GLUtil.DEVICE_TEXTURE_LIMIT > GLUtil.SAFE_TEXTURE_LIMIT) {
+                val entries = GLUtil.CUSTOM_TEXTURE_LIMIT_OPTIONS
+                    .mapIndexed { index, option ->
+                        val display = if (index == 0) {
+                            context.getString(MR.strings.pref_hardware_bitmap_threshold_default, option)
+                        } else {
+                            option.toString()
+                        }
+                        option to display
+                    }
+                    .toMap()
+                    .toImmutableMap()
+                add(Preference.PreferenceItem.ListPreference(
+                    pref = basePreferences.hardwareBitmapThreshold(),
+                    title = stringResource(MR.strings.pref_hardware_bitmap_threshold),
+                    subtitle = stringResource(MR.strings.pref_hardware_bitmap_threshold_summary, "%s"),
+                    entries = entries,
+                    onValueChanged = {
+                        Logger.i(LOG_TAG) { "hardwareBitmapThreshold → $it" }
+                        true
+                    },
+                ))
+            }
+            add(Preference.PreferenceItem.TextPreference(
+                title = stringResource(MR.strings.pref_display_profile),
+                subtitle = displayProfileSubtitle,
+                onClick = {
+                    Logger.i(LOG_TAG) { "display profile picker opened" }
+                    (context as? MainActivity)?.showColourProfilePicker()
+                },
+            ))
+            add(Preference.PreferenceItem.SwitchPreference(
+                pref = readerPreferences.debugMode(),
+                title = stringResource(MR.strings.pref_reader_debug_mode),
+                onValueChanged = {
+                    Logger.i(LOG_TAG) { "readerDebugMode → $it" }
+                    true
+                },
+            ))
+        }.toPersistentList()
+
+        return Preference.PreferenceGroup(
+            title = stringResource(MR.strings.reader),
+            preferenceItems = children,
+        )
+    }
+
+    @Composable
+    private fun getLocalSourceGroup(): Preference.PreferenceGroup {
+        val sourcePreferences: SourcePreferences by injectLazy()
+
+        // FIXME: Add beta tag support to preference item — matches the FIXME in getLibraryGroup.
+        return Preference.PreferenceGroup(
+            title = stringResource(MR.strings.local_source),
+            preferenceItems = listOf(
+                Preference.PreferenceItem.SwitchPreference(
+                    pref = sourcePreferences.externalLocalSource(),
+                    title = stringResource(MR.strings.pref_external_local_source),
+                    onValueChanged = {
+                        Logger.i(LOG_TAG) { "externalLocalSource → $it" }
+                        true
+                    },
+                ),
+            ).toPersistentList(),
+        )
+    }
+
+    @Composable
     private fun getDeveloperGroup(): Preference.PreferenceGroup {
         val navigator = LocalNavigator.currentOrThrow
+        val context = LocalContext.current
+        val scope = rememberCoroutineScope()
+        val alertDialog = LocalDialogHostState.currentOrThrow
 
         val children = buildList {
             add(Preference.PreferenceItem.TextPreference(
                 title = "Storybook",
-                onClick = { navigator.push(StoryBookScreen()) },
+                onClick = {
+                    Logger.i(LOG_TAG) { "storybook clicked" }
+                    navigator.push(StoryBookScreen())
+                },
             ))
+            if (BuildConfig.FLAVOR == "dev" || BuildConfig.DEBUG || BuildConfig.NIGHTLY) {
+                add(Preference.PreferenceItem.TextPreference(
+                    title = "Crash the app!",
+                    subtitle = "To test crashes",
+                    onClick = {
+                        Logger.i(LOG_TAG) { "crash the app clicked" }
+                        scope.launch {
+                            alertDialog.simple {
+                                titleRes = MR.strings.warning
+                                text = "I told you this would crash the app, why would you want that?"
+                                confirmText = "Crash it anyway"
+                                onConfirm = { throw RuntimeException("Fell into the void") }
+                            }
+                        }
+                    },
+                ))
+                add(Preference.PreferenceItem.TextPreference(
+                    title = "Prune finished workers",
+                    subtitle = "In case worker stuck in FAILED state and you're too impatient to wait",
+                    onClick = {
+                        Logger.i(LOG_TAG) { "prune finished workers clicked" }
+                        scope.launch {
+                            alertDialog.simple {
+                                title = "Are you sure?"
+                                text = "Failed workers should clear out by itself eventually, this option should only be used if you're being impatient and you know what you're doing."
+                                confirmText = "Prune"
+                                onConfirm = { context.workManager.pruneWork() }
+                            }
+                        }
+                    },
+                ))
+            }
         }.toPersistentList()
 
         return Preference.PreferenceGroup(

--- a/app/src/main/java/yokai/presentation/settings/screen/SettingsAdvancedScreen.kt
+++ b/app/src/main/java/yokai/presentation/settings/screen/SettingsAdvancedScreen.kt
@@ -9,7 +9,6 @@ import android.webkit.WebStorage
 import android.webkit.WebView
 import android.widget.Toast
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -91,8 +90,6 @@ import yokai.presentation.settings.screen.advanced.awaitCleanupDownloadedChapter
 
 object SettingsAdvancedScreen : ComposableSettings() {
 
-    private const val LOG_TAG = "SettingsAdvancedScreen"
-
     private fun readResolve() = SettingsAdvancedScreen
 
     @Composable
@@ -104,10 +101,6 @@ object SettingsAdvancedScreen : ComposableSettings() {
         val basePreferences: BasePreferences by injectLazy()
         val networkPreferences: NetworkPreferences by injectLazy()
         val isUpdaterEnabled = BuildConfig.INCLUDE_UPDATER
-
-        LaunchedEffect(Unit) {
-            Logger.i(LOG_TAG) { "entered compose advanced settings" }
-        }
 
         return buildList {
             add(Preference.PreferenceItem.SwitchPreference(
@@ -248,21 +241,14 @@ object SettingsAdvancedScreen : ComposableSettings() {
             add(Preference.PreferenceItem.TextPreference(
                 title = stringResource(MR.strings.force_download_cache_refresh),
                 subtitle = stringResource(MR.strings.force_download_cache_refresh_summary),
-                onClick = {
-                    Logger.i(LOG_TAG) { "force download cache refresh" }
-                    downloadManager.refreshCache()
-                },
+                onClick = { downloadManager.refreshCache() },
             ))
             add(Preference.PreferenceItem.TextPreference(
                 title = stringResource(MR.strings.clean_up_downloaded_chapters),
                 subtitle = stringResource(MR.strings.delete_unused_chapters),
                 onClick = {
-                    Logger.i(LOG_TAG) { "clean up downloaded chapters clicked" }
                     scope.launch {
                         val opts = alertDialog.awaitCleanupDownloadedChapters() ?: return@launch
-                        Logger.i(LOG_TAG) {
-                            "cleanup options → deleteRead=${opts.deleteRead}, deleteNonFavorite=${opts.deleteNonFavorite}"
-                        }
                         cleanupDownloads(
                             context = context,
                             downloadManager = downloadManager,
@@ -502,7 +488,6 @@ object SettingsAdvancedScreen : ComposableSettings() {
             add(Preference.PreferenceItem.TextPreference(
                 title = stringResource(MR.strings.action_revoke_all_extensions),
                 onClick = {
-                    Logger.i(LOG_TAG) { "revoke all extensions clicked" }
                     scope.launch {
                         alertDialog.simple {
                             titleRes = MR.strings.confirm_revoke_all_extensions
@@ -583,27 +568,16 @@ object SettingsAdvancedScreen : ComposableSettings() {
                     title = stringResource(MR.strings.pref_hardware_bitmap_threshold),
                     subtitle = stringResource(MR.strings.pref_hardware_bitmap_threshold_summary, "%s"),
                     entries = entries,
-                    onValueChanged = {
-                        Logger.i(LOG_TAG) { "hardwareBitmapThreshold → $it" }
-                        true
-                    },
                 ))
             }
             add(Preference.PreferenceItem.TextPreference(
                 title = stringResource(MR.strings.pref_display_profile),
                 subtitle = displayProfileSubtitle,
-                onClick = {
-                    Logger.i(LOG_TAG) { "display profile picker opened" }
-                    (context as? MainActivity)?.showColourProfilePicker()
-                },
+                onClick = { (context as? MainActivity)?.showColourProfilePicker() },
             ))
             add(Preference.PreferenceItem.SwitchPreference(
                 pref = readerPreferences.debugMode(),
                 title = stringResource(MR.strings.pref_reader_debug_mode),
-                onValueChanged = {
-                    Logger.i(LOG_TAG) { "readerDebugMode → $it" }
-                    true
-                },
             ))
         }.toPersistentList()
 
@@ -624,10 +598,6 @@ object SettingsAdvancedScreen : ComposableSettings() {
                 Preference.PreferenceItem.SwitchPreference(
                     pref = sourcePreferences.externalLocalSource(),
                     title = stringResource(MR.strings.pref_external_local_source),
-                    onValueChanged = {
-                        Logger.i(LOG_TAG) { "externalLocalSource → $it" }
-                        true
-                    },
                 ),
             ).toPersistentList(),
         )
@@ -643,17 +613,13 @@ object SettingsAdvancedScreen : ComposableSettings() {
         val children = buildList {
             add(Preference.PreferenceItem.TextPreference(
                 title = "Storybook",
-                onClick = {
-                    Logger.i(LOG_TAG) { "storybook clicked" }
-                    navigator.push(StoryBookScreen())
-                },
+                onClick = { navigator.push(StoryBookScreen()) },
             ))
             if (BuildConfig.FLAVOR == "dev" || BuildConfig.DEBUG || BuildConfig.NIGHTLY) {
                 add(Preference.PreferenceItem.TextPreference(
                     title = "Crash the app!",
                     subtitle = "To test crashes",
                     onClick = {
-                        Logger.i(LOG_TAG) { "crash the app clicked" }
                         scope.launch {
                             alertDialog.simple {
                                 titleRes = MR.strings.warning
@@ -668,7 +634,6 @@ object SettingsAdvancedScreen : ComposableSettings() {
                     title = "Prune finished workers",
                     subtitle = "In case worker stuck in FAILED state and you're too impatient to wait",
                     onClick = {
-                        Logger.i(LOG_TAG) { "prune finished workers clicked" }
                         scope.launch {
                             alertDialog.simple {
                                 title = "Are you sure?"

--- a/app/src/main/java/yokai/presentation/settings/screen/SettingsSecurityScreen.kt
+++ b/app/src/main/java/yokai/presentation/settings/screen/SettingsSecurityScreen.kt
@@ -3,10 +3,8 @@ package yokai.presentation.settings.screen
 import android.app.Activity
 import androidx.biometric.BiometricPrompt
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.platform.LocalContext
 import androidx.fragment.app.FragmentActivity
-import co.touchlab.kermit.Logger
 import dev.icerock.moko.resources.StringResource
 import dev.icerock.moko.resources.compose.pluralStringResource
 import dev.icerock.moko.resources.compose.stringResource
@@ -27,8 +25,6 @@ import yokai.presentation.settings.ComposableSettings
 
 object SettingsSecurityScreen : ComposableSettings() {
 
-    private const val LOG_TAG = "SettingsSecurityScreen"
-
     private fun readResolve() = SettingsSecurityScreen
 
     @Composable
@@ -39,10 +35,6 @@ object SettingsSecurityScreen : ComposableSettings() {
         val securityPreferences: SecurityPreferences by injectLazy()
         val preferences: PreferencesHelper by injectLazy()
         val context = LocalContext.current
-
-        LaunchedEffect(Unit) {
-            Logger.i(LOG_TAG) { "entered compose security settings" }
-        }
 
         return buildList {
             if (context.isAuthenticationSupported()) {
@@ -69,7 +61,6 @@ object SettingsSecurityScreen : ComposableSettings() {
             pref = pref,
             title = title,
             onValueChanged = { newValue ->
-                Logger.i(LOG_TAG) { "useBiometrics → $newValue" }
                 val activity = context as? FragmentActivity
                 if (activity != null && context.isAuthenticationSupported()) {
                     activity.startAuthentication(
@@ -110,10 +101,6 @@ object SettingsSecurityScreen : ComposableSettings() {
             pref = preferences.lockAfter(),
             title = stringResource(MR.strings.lock_when_idle),
             entries = entries,
-            onValueChanged = {
-                Logger.i(LOG_TAG) { "lockAfter → $it" }
-                true
-            },
         )
     }
 
@@ -122,10 +109,6 @@ object SettingsSecurityScreen : ComposableSettings() {
         return Preference.PreferenceItem.SwitchPreference(
             pref = preferences.hideNotificationContent(),
             title = stringResource(MR.strings.hide_notification_content),
-            onValueChanged = {
-                Logger.i(LOG_TAG) { "hideNotificationContent → $it" }
-                true
-            },
         )
     }
 
@@ -141,7 +124,6 @@ object SettingsSecurityScreen : ComposableSettings() {
             title = stringResource(MR.strings.secure_screen),
             entries = entries,
             onValueChanged = {
-                Logger.i(LOG_TAG) { "secureScreen → $it" }
                 SecureActivityDelegate.setSecure(context as? Activity)
                 true
             },

--- a/app/src/main/java/yokai/presentation/settings/screen/advanced/AlertDialogs.kt
+++ b/app/src/main/java/yokai/presentation/settings/screen/advanced/AlertDialogs.kt
@@ -26,9 +26,13 @@ data class CleanupChaptersOptions(
 suspend fun DialogHostState.awaitCleanupDownloadedChapters(): CleanupChaptersOptions? = dialog { cont ->
     var deleteRead by rememberSaveable { mutableStateOf(true) }
     var deleteNonFavorite by rememberSaveable { mutableStateOf(true) }
+    val resume: (CleanupChaptersOptions?) -> Unit = { value ->
+        // Guard against rapid double-taps (confirm + dismiss landing in the same frame)
+        if (cont.isActive) cont.resume(value)
+    }
 
     AlertDialog(
-        onDismissRequest = { cont.resume(null) },
+        onDismissRequest = { resume(null) },
         title = { Text(text = stringResource(MR.strings.clean_up_downloaded_chapters)) },
         text = {
             Box {
@@ -61,13 +65,13 @@ suspend fun DialogHostState.awaitCleanupDownloadedChapters(): CleanupChaptersOpt
         },
         confirmButton = {
             TextButton(onClick = {
-                cont.resume(CleanupChaptersOptions(deleteRead = deleteRead, deleteNonFavorite = deleteNonFavorite))
+                resume(CleanupChaptersOptions(deleteRead = deleteRead, deleteNonFavorite = deleteNonFavorite))
             }) {
                 Text(stringResource(AR.string.ok))
             }
         },
         dismissButton = {
-            TextButton(onClick = { cont.resume(null) }) {
+            TextButton(onClick = { resume(null) }) {
                 Text(stringResource(AR.string.cancel))
             }
         },

--- a/app/src/main/java/yokai/presentation/settings/screen/advanced/AlertDialogs.kt
+++ b/app/src/main/java/yokai/presentation/settings/screen/advanced/AlertDialogs.kt
@@ -1,0 +1,75 @@
+package yokai.presentation.settings.screen.advanced
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.res.stringResource
+import dev.icerock.moko.resources.compose.stringResource
+import kotlin.coroutines.resume
+import yokai.domain.DialogHostState
+import yokai.i18n.MR
+import yokai.presentation.component.LabeledCheckbox
+import android.R as AR
+
+data class CleanupChaptersOptions(
+    val deleteRead: Boolean,
+    val deleteNonFavorite: Boolean,
+)
+
+suspend fun DialogHostState.awaitCleanupDownloadedChapters(): CleanupChaptersOptions? = dialog { cont ->
+    var deleteRead by rememberSaveable { mutableStateOf(true) }
+    var deleteNonFavorite by rememberSaveable { mutableStateOf(true) }
+
+    AlertDialog(
+        onDismissRequest = { cont.resume(null) },
+        title = { Text(text = stringResource(MR.strings.clean_up_downloaded_chapters)) },
+        text = {
+            Box {
+                val state = rememberLazyListState()
+                LazyColumn(state = state) {
+                    item {
+                        LabeledCheckbox(
+                            label = stringResource(MR.strings.clean_orphaned_downloads),
+                            checked = true,
+                            onCheckedChange = {},
+                            enabled = false,
+                        )
+                    }
+                    item {
+                        LabeledCheckbox(
+                            label = stringResource(MR.strings.clean_read_downloads),
+                            checked = deleteRead,
+                            onCheckedChange = { deleteRead = it },
+                        )
+                    }
+                    item {
+                        LabeledCheckbox(
+                            label = stringResource(MR.strings.clean_read_manga_not_in_library),
+                            checked = deleteNonFavorite,
+                            onCheckedChange = { deleteNonFavorite = it },
+                        )
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = {
+                cont.resume(CleanupChaptersOptions(deleteRead = deleteRead, deleteNonFavorite = deleteNonFavorite))
+            }) {
+                Text(stringResource(AR.string.ok))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = { cont.resume(null) }) {
+                Text(stringResource(AR.string.cancel))
+            }
+        },
+    )
+}

--- a/docs/dev/development.md
+++ b/docs/dev/development.md
@@ -190,15 +190,17 @@ All implemented in `app/`:
 
 Settings navigation is driven by `app/src/main/java/eu/kanade/tachiyomi/ui/setting/controllers/SettingsMainController.kt`, which maps each section to its screen.
 
-**Two-screen pattern:** every settings section has two parallel implementations:
-- **Legacy Conductor controller** in `app/.../ui/setting/controllers/legacy/` — this is what users see by default
-- **Compose screen** in `app/.../yokai/presentation/settings/screen/` — experimental, not yet the default for most sections
+**Two-screen pattern:** each settings section can have two parallel implementations during its migration:
+- **Compose screen** in `app/.../yokai/presentation/settings/screen/` — the target stack (Compose + Voyager).
+- **Legacy Conductor controller** in `app/.../ui/setting/controllers/legacy/` — kept as a long-press fallback during the soak period after a section flips.
 
-**When adding or editing settings UI, changes must go to the legacy controller.** The Compose screen won't be visible to users until the migration for that section is complete.
+**Per-section state:**
+- **Security**, **Data and storage**, **Advanced** — Compose by default (tap). Long-press reaches the legacy version, which prints a `"You're entering legacy version of …"` toast.
+- **General**, **Appearance**, **Library**, **Reader**, **Downloads**, **Browse**, **Tracking**, **About** — legacy only. No Compose port yet.
 
-**Advanced settings specifically:**
-- Normal tap → `SettingsAdvancedLegacyController` (legacy, what users see)
-- Long-press → `SettingsAdvancedController` → `SettingsAdvancedScreen` (Compose, experimental)
+**When adding or editing settings UI for a section that has flipped:** changes go to the Compose screen. The legacy controller stays alive during the soak period so that the Settings search (which still indexes legacy controllers — see `SettingsSearchHelper.kt`) keeps surfacing results for migrated sections.
+
+**When adding or editing settings UI for a section that has not flipped:** changes go to the legacy controller. The Compose screen, if any, is invisible to users until that section's migration is complete and the routing is flipped.
 
 ## Build Gotchas
 


### PR DESCRIPTION
## Summary

- Brings the Compose Advanced screen to feature parity with its legacy counterpart and makes it the default (tap). Long-press still falls back to the legacy preferences screen.
- Adds a per-use-case `awaitCleanupDownloadedChapters` dialog helper following the established `awaitCreateBackup` pattern. Mirrors `awaitX` style rather than introducing a generic builder.
- Removes the Kermit soak-test probes that were temporarily added to the Security and Advanced Compose screens.
- Refreshes the Settings two-screen-pattern docs in `docs/dev/development.md` and `.claude/rules/architecture.md` to reflect the new default routing.

## What landed

| Gap | Status |
| --- | --- |
| Clean up downloaded chapters | Wired (new dialog helper + lifted cleanupDownloads body) |
| Revoke all extensions | Wired (alertDialog.simple confirm → TrustExtension.revokeAll) |
| Reader category | Added (hardware bitmap threshold, color profile picker, reader debug mode) |
| Local source category | Added (external local source switch) |
| Developer category | Crash + Prune (gated on dev/debug/nightly) |
| Default routing | Tap → Compose, long-press → Legacy |

Legacy controller is intentionally **not** removed — `SettingsSearchHelper` still indexes it, and Compose-side search indexing is upstream-blocked.