### PR TITLE
docs(dev): flip Downloads to Compose in migration status table

### DIFF
--- a/docs/dev/settings-compose-migration.md
+++ b/docs/dev/settings-compose-migration.md
@@ -15,7 +15,7 @@ Start by reading the **Status** table to see where things stand, then jump to **
 | Appearance | Legacy | — |
 | Library | Legacy | — |
 | Reader | Legacy | — |
-| Downloads | Legacy | — |
+| Downloads | Compose | Legacy |
 | Browse | Legacy | — |
 | Tracking | Legacy | — |
 | About | Compose | — (no legacy) |


### PR DESCRIPTION
## Summary

- Updates the Status table in `docs/dev/settings-compose-migration.md` to mark Downloads as Compose-default with a legacy long-press fallback, matching what landed in #3.