### PR TITLE
test: expand unit coverage; fix latent cookie and extension-load bugs

### DIFF
--- a/.claude/skills/code-research/SKILL.md
+++ b/.claude/skills/code-research/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: code-research
+description: Deep, fan-out research over the codebase to answer a big question (test gaps, how a subsystem works end to end, a risk/security/dead-code audit, "where does X happen everywhere"). The codebase analog of deep web research: parallel explorer agents gather file:line-cited findings, surprising or high-stakes claims are adversarially verified against current code, and the result is a single prioritized report. Use for broad/deep questions that span many files and modules, NOT a one-file lookup and NOT a single-task pre-plan (use /scout for that, /explain for one thing).
+argument-hint: "<research question> (e.g. 'where are our unit-test gaps', 'how does backup/restore work end to end', 'audit the EXH subsystem for risk')"
+disable-model-invocation: false
+allowed-tools:
+  - Bash(git *)
+  - Glob
+  - Grep
+  - Read
+  - Agent
+---
+
+# code-research
+
+The codebase analog of the web `deep-research` harness. Where deep-research fans out web searches, fetches sources, fact-checks claims, and synthesizes a cited report, this fans out **code exploration**, reads **files**, verifies claims against **current code**, and synthesizes a report cited by **`file:line`** instead of URLs.
+
+**This skill never edits code.** It produces a findings report. Acting on it (writing tests, fixing bugs, refactoring) happens after, as a separate step the user approves.
+
+## When to use
+
+- Broad/deep questions spanning many files or whole subsystems: "where are our test gaps", "how does the merge engine work end to end", "audit the adult-source subsystem", "where is untrusted input handled", "what's dead code".
+- Audits where you want coverage AND confidence (adversarial verification), not just a quick pointer.
+
+## When NOT to use
+
+- A single fact or one-file lookup. Just read it.
+- Pre-planning ONE concrete task (port this screen, add this feature). Use `/scout`, it is lighter and task-scoped.
+- Explaining one already-located thing. Use `/explain`.
+
+If invoked for something trivial, push back once and suggest the lighter tool.
+
+## Method
+
+### 1. Scope and clarify
+
+Echo the research question in one sentence so the user can correct a misread before agents spend tokens. If it's vague (which subsystem? what aspect? what counts as a "gap"/"risk"?), use `AskUserQuestion` to narrow, do not fan out on a fuzzy question. Decide the **angle of decomposition** (by module, by data flow, by concern) and the **inclusion bar** (what counts as a finding vs noise).
+
+### 2. Map the terrain (cheap reads, main thread)
+
+Before spawning anything, inventory on the main thread so the subagents are briefed well and don't rediscover the obvious:
+
+- The relevant files/modules (`Glob`, `Grep`), and for test questions, the existing test inventory (so agents don't re-flag covered ground).
+- `git log --oneline -20` for recent shape; `Handoff.md` / `.claude/rules/*` / plan docs for known constraints and deliberate descopes (the most common audit failure is flagging deferred work as missing).
+- Note what is already covered / out of scope, verbatim, to hand to every agent.
+
+### 3. Fan out parallel explorers (the "searches")
+
+Split the question into 3-6 independent areas/angles and spawn one `Agent` (`subagent_type: Explore`) per area, **all in one message so they run in parallel**. Brief each as a smart colleague who hasn't seen this conversation:
+
+- State the goal and the inclusion bar (what's a finding, what's noise).
+- Hand over exact paths/globs and the **already-covered / out-of-scope list** so they don't re-flag it.
+- Demand a `file:line` for every concrete claim.
+- Ask for prioritization (High/Med/Low) and, for each finding, the one-line "why it matters".
+- Cap each response (~500-700 words) and require an "uncertain / would-need-to-confirm" section.
+- Scale the fan-out to the question: a few agents for a focused audit, more (and a second round) for "be exhaustive".
+
+Explore agents locate and summarize; they don't deeply verify. That's the next step.
+
+### 4. Adversarially verify (the fact-check)
+
+Do NOT trust agent summaries wholesale. On the main thread, **re-read the current code** for the highest-stakes, most surprising, or most "bug-like" claims and kill the false positives. Typical kills:
+
+- "X is untested" when a test exists; "X doesn't exist" when it moved/renamed.
+- A flagged "bug" that the surrounding code already handles, or that can't actually be reached.
+- A finding that is **deliberately deferred** (check the descope list from step 2) rather than a real gap.
+- Misjudged testability (e.g. "add a unit test" for logic that hardcodes a clock / does real I/O and would need a refactor first).
+
+Trust current code over memory, Handoff, and agent text. Label each surviving finding by confidence: **verified** (you re-read it) vs **reported** (agent-cited, not re-read). For exhaustive audits, verification can itself fan out (one skeptic per top finding); for a normal pass, spot-check the top handful inline.
+
+### 5. Synthesize the report
+
+One report into the conversation (don't write a file unless asked). Structure:
+
+```
+# Code research: <question>
+
+## Answer / headline
+<2-3 sentences: the bottom line>
+
+## Findings (prioritized, deduped)
+### High
+- [file.kt:42](path:42) — what it is, why it matters, (verified|reported). For test gaps: what a test would assert.
+### Medium
+...
+### Low / needs-refactor-first
+...
+
+## Already covered / deliberately deferred (so it's not re-flagged later)
+- ...
+
+## Open questions / still unknown
+- ...
+
+## Recommended next step
+<the first batch to act on, if any>
+```
+
+Rules for the report: every concrete claim cites `file:line` from code you or an agent actually read; dedupe overlapping findings from different agents; separate "real gap" from "already covered" from "deferred"; note testability honestly (pure/easy vs needs-mocking vs needs-refactor). No em dashes.
+
+### 6. Hand off
+
+End with "Ready to act" + the recommended first batch, or "Open questions block this". Do not start writing tests/fixes/refactors, the user decides whether and what to action.
+
+## Scale knob (optional)
+
+Default is a single fan-out + inline verification. For "be exhaustive" / large audits, do multiple rounds (loop until a round surfaces nothing new), add a per-finding adversarial verifier pass, and a final completeness critic ("what area/angle did we not cover?"). If the user has explicitly opted into multi-agent orchestration, the `Workflow` tool can run this find -> dedupe -> verify pipeline deterministically; otherwise use parallel `Agent` calls.
+
+## Rules
+
+- Read-only. Never edits, never writes code, never starts the fix.
+- Every concrete claim cites `file:line` from current code. Memory/Handoff/agent-summary claims are hypotheses until cited.
+- Surface stale memories/docs found along the way instead of acting on them.
+- Cap the synthesized report (~1500 words). A bigger answer means the question needed splitting, not a longer report.
+- No em dashes. Commas, parentheses, periods, colons.

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -1,10 +1,17 @@
-name: Build PR
+name: Build & test
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - '**.md'
+      - '.github/**'
+      - '.claude/**'
+      - 'docs/**'
   pull_request:
     paths:
       - '**'
@@ -48,7 +55,7 @@ jobs:
         run: ./gradlew assembleRelease
 
       - name: Run unit tests
-        run: ./gradlew testReleaseUnitTest
+        run: ./gradlew test
 
       - name: Publish test report
         uses: mikepenz/action-junit-report@v5

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -62,6 +62,9 @@ jobs:
           mkdir -p ~/.gradle
           cp .github/runner-files/ci-gradle.properties ~/.gradle/gradle.properties
 
+      - name: Run unit tests
+        run: ./gradlew test
+
       - name: Build signed preview APKs
         run: ./gradlew assemblePreview -Penable-updater
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,9 @@ jobs:
             echo "VERSION_TAG=${{ github.ref_name }}" >> $GITHUB_ENV
           fi
 
+      - name: Run unit tests
+        run: ./gradlew test
+
       - name: Build signed release APKs
         run: ./gradlew assembleRelease -Penable-updater
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Reikai uses its own [Semantic Versioning](https://semver.org/) from the Mihon-ba
 ### Other
 
 - Expanded automated test coverage for backup restore, novel chapter sync, and gallery metadata parsing, and fixed an internal cookie-removal helper that could miss cookies after the first.
+- Stopped logging a harmless cast error for every installed extension at startup (the extension lib version is now read without the failing conversion).
 
 ## [0.1.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Reikai uses its own [Semantic Versioning](https://semver.org/) from the Mihon-ba
 
 ## [Unreleased]
 
+### Other
+
+- Expanded automated test coverage for backup restore, novel chapter sync, and gallery metadata parsing, and fixed an internal cookie-removal helper that could miss cookies after the first.
+
 ## [0.1.0]
 
 ### Additions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Reikai uses its own [Semantic Versioning](https://semver.org/) from the Mihon-ba
 
 ## [Unreleased]
 
+## [0.1.1]
+
 ### Other
 
 - Expanded automated test coverage for backup restore, novel chapter sync, and gallery metadata parsing, and fixed an internal cookie-removal helper that could miss cookies after the first.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -39,8 +39,8 @@ android {
         // versionCode must keep climbing and stay above the last Yokai-based build (168) so installs upgrade in place.
         applicationId = "eu.kanade.tachiyomi"
 
-        versionCode = 170
-        versionName = "0.1.0"
+        versionCode = 171
+        versionName = "0.1.1"
         // RK <--
 
         buildConfigField("String", "COMMIT_COUNT", "\"${getLatestCommitCount()}\"")

--- a/app/src/main/java/eu/kanade/tachiyomi/extension/util/ExtensionLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/extension/util/ExtensionLoader.kt
@@ -51,7 +51,7 @@ internal object ExtensionLoader {
     private const val METADATA_NSFW = "tachiyomi.extension.nsfw"
 
     private const val METADATA_NAME = "tachiyomix.name"
-    private const val METADATA_EXTENSION_LIB = "tachiyomix.extensionLib"
+    // RK: removed METADATA_EXTENSION_LIB read (lib version now derived from versionName); see loadExtension.
     private const val METADATA_CONTENT_WARNING = "tachiyomix.contentWarning"
 
     const val LIB_VERSION_MIN = 1.4
@@ -244,8 +244,10 @@ internal object ExtensionLoader {
         }
 
         // Validate lib version
-        val libVersion = appInfo.metaData.getDouble(METADATA_EXTENSION_LIB).takeUnless { it == 0.0 }
-            ?: versionName.substringBeforeLast('.').toDoubleOrNull()
+        // RK: the extensionLib manifest value is a float, so getDouble() always failed the cast
+        // (logging a full stack at every extension load) and we fell back to the versionName-derived
+        // value anyway. Derive it directly to silence that startup noise (matches Komikku).
+        val libVersion = versionName.substringBeforeLast('.').toDoubleOrNull()
         if (libVersion == null || (libVersion != LIB_VERSION_MIN && libVersion != LIB_VERSION_MAX)) {
             logcat(LogPriority.WARN) {
                 "Lib version is $libVersion, while only versions " +

--- a/app/src/main/java/exh/util/ThrottleManager.kt
+++ b/app/src/main/java/exh/util/ThrottleManager.kt
@@ -14,13 +14,15 @@ import kotlin.time.Duration.Companion.seconds
 class ThrottleManager(
     private val max: Duration = THROTTLE_MAX,
     private val inc: Duration = THROTTLE_INC,
+    // Clock seam: defaults to the wall clock; tests inject a fixed source to assert the escalation.
+    private val now: () -> Duration = { System.currentTimeMillis().milliseconds },
 ) {
     private var lastThrottleTime = Duration.ZERO
     private var throttleTime = Duration.ZERO
 
     suspend fun throttle() {
-        val now = System.currentTimeMillis().milliseconds
-        val timeDiff = now - lastThrottleTime
+        val currentTime = now()
+        val timeDiff = currentTime - lastThrottleTime
         if (timeDiff < throttleTime) {
             delay(throttleTime - timeDiff)
         }
@@ -29,7 +31,7 @@ class ThrottleManager(
             throttleTime += inc
         }
 
-        lastThrottleTime = System.currentTimeMillis().milliseconds
+        lastThrottleTime = now()
     }
 
     companion object {

--- a/app/src/main/java/reikai/novel/host/LnHostBridge.kt
+++ b/app/src/main/java/reikai/novel/host/LnHostBridge.kt
@@ -129,7 +129,8 @@ class LnHostBridge(
      * string or FormData. The bridge accepts only the JSON-friendly subset; the runtime serializes
      * FormData to a urlencoded string before it reaches here.
      */
-    private fun parseFetchOpts(optsJson: String): FetchOpts {
+    // internal (not private) so the lenient parse fallback is unit-testable.
+    internal fun parseFetchOpts(optsJson: String): FetchOpts {
         if (optsJson.isBlank() || optsJson == "{}") return FetchOpts()
         return try {
             JSON.decodeFromString(FetchOpts.serializer(), optsJson)
@@ -148,7 +149,7 @@ class LnHostBridge(
     }
 
     @Serializable
-    private data class FetchOpts(
+    internal data class FetchOpts(
         val method: String? = null,
         val headers: Map<String, String>? = null,
         val body: String? = null,

--- a/app/src/test/java/eu/kanade/tachiyomi/data/backup/MangaMergeBackupRoundTripTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/data/backup/MangaMergeBackupRoundTripTest.kt
@@ -37,6 +37,7 @@ class MangaMergeBackupRoundTripTest {
         insertTrack = mockk(relaxed = true),
         fetchInterval = mockk(relaxed = true),
         reikaiLibraryPreferences = prefs,
+        mangaMetadataRepository = mockk(relaxed = true),
     )
 
     @Test

--- a/app/src/test/java/eu/kanade/tachiyomi/data/backup/MangaRestoreCategoriesTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/data/backup/MangaRestoreCategoriesTest.kt
@@ -1,0 +1,94 @@
+package eu.kanade.tachiyomi.data.backup
+
+import app.cash.sqldelight.SuspendingTransactionWithoutReturn
+import eu.kanade.tachiyomi.data.backup.models.BackupCategory
+import eu.kanade.tachiyomi.data.backup.models.BackupManga
+import eu.kanade.tachiyomi.data.backup.restore.restorers.MangaRestorer
+import io.kotest.matchers.collections.shouldContainExactly
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import tachiyomi.data.Database
+import tachiyomi.domain.category.interactor.GetCategories
+import tachiyomi.domain.category.model.Category
+import tachiyomi.domain.chapter.interactor.GetChaptersByMangaId
+import tachiyomi.domain.manga.interactor.GetMangaByUrlAndSourceId
+import tachiyomi.domain.manga.model.Manga
+
+/**
+ * Backups store a manga's categories as the *order* indices of the source device's categories, never
+ * names or ids (ids differ per device). On restore each order is mapped back through the backup's own
+ * category list to a name, then to whatever id that name has on this device. A category whose name
+ * doesn't exist locally is dropped rather than mis-assigned. This guards that remap, the highest
+ * data-loss-risk corner of restore.
+ */
+class MangaRestoreCategoriesTest {
+
+    private val deviceCategories = listOf(
+        Category(id = 100, name = "Reading", order = 0, flags = 0),
+        Category(id = 200, name = "Completed", order = 1, flags = 0),
+    )
+
+    // Backup-side categories: same names, different orders/ids, plus one ("Ghost") absent locally.
+    private val backupCategories = listOf(
+        BackupCategory(name = "Reading", order = 5),
+        BackupCategory(name = "Completed", order = 9),
+        BackupCategory(name = "Ghost", order = 3),
+    )
+
+    /**
+     * Runs [backupManga] through restore() against [deviceCategories] and returns the category ids
+     * the manga gets assigned (the second arg of each mangas_categories insert).
+     */
+    private suspend fun restoredCategoryIds(backupManga: BackupManga): List<Long> {
+        val insertedCategoryIds = mutableListOf<Long>()
+        val database = mockk<Database>(relaxed = true) {
+            // Run the suspend transaction body inline so the inserts actually fire.
+            coEvery { transaction(any(), any()) } coAnswers {
+                // arg 0 = noEnclosing, arg 1 = the suspend body (arg 2 is the continuation).
+                secondArg<suspend SuspendingTransactionWithoutReturn.() -> Unit>().invoke(mockk(relaxed = true))
+            }
+            coEvery { mangas_categoriesQueries.insert(any(), any()) } coAnswers {
+                val categoryId = secondArg<Long>()
+                insertedCategoryIds.add(categoryId)
+                categoryId
+            }
+        }
+        // Existing-manga path (dbManga != null) avoids the insertReturningId(...).awaitAsOne() of the
+        // new-manga branch, which a relaxed mock can't satisfy.
+        val dbManga = Manga.create().copy(id = 7, url = "u", source = 1L)
+        val restorer = MangaRestorer(
+            database = database,
+            getCategories = mockk { coEvery { await() } returns deviceCategories },
+            getMangaByUrlAndSourceId = mockk<GetMangaByUrlAndSourceId> {
+                coEvery { await("u", 1L) } returns dbManga
+            },
+            getChaptersByMangaId = mockk<GetChaptersByMangaId> { coEvery { await(7) } returns emptyList() },
+            updateManga = mockk(relaxed = true),
+            getTracks = mockk(relaxed = true),
+            insertTrack = mockk(relaxed = true),
+            fetchInterval = mockk(relaxed = true),
+            reikaiLibraryPreferences = mockk(relaxed = true),
+            mangaMetadataRepository = mockk(relaxed = true),
+        )
+
+        restorer.restore(backupManga, backupCategories)
+        return insertedCategoryIds
+    }
+
+    @Test
+    fun `category orders map through backup names to this device's category ids`() = runTest {
+        val backupManga = BackupManga(source = 1L, url = "u", title = "T", categories = listOf(5, 9))
+
+        restoredCategoryIds(backupManga) shouldContainExactly listOf(100, 200)
+    }
+
+    @Test
+    fun `a category whose name is absent locally is dropped`() = runTest {
+        // Order 3 is "Ghost", which has no match in deviceCategories.
+        val backupManga = BackupManga(source = 1L, url = "u", title = "T", categories = listOf(5, 3, 9))
+
+        restoredCategoryIds(backupManga) shouldContainExactly listOf(100, 200)
+    }
+}

--- a/app/src/test/java/eu/kanade/tachiyomi/data/backup/MangaRestoreChaptersTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/data/backup/MangaRestoreChaptersTest.kt
@@ -1,0 +1,88 @@
+package eu.kanade.tachiyomi.data.backup
+
+import app.cash.sqldelight.SuspendingTransactionWithoutReturn
+import eu.kanade.tachiyomi.data.backup.models.BackupChapter
+import eu.kanade.tachiyomi.data.backup.models.BackupManga
+import eu.kanade.tachiyomi.data.backup.restore.restorers.MangaRestorer
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import tachiyomi.data.Database
+import tachiyomi.domain.chapter.interactor.GetChaptersByMangaId
+import tachiyomi.domain.chapter.model.Chapter
+import tachiyomi.domain.manga.interactor.GetMangaByUrlAndSourceId
+import tachiyomi.domain.manga.model.Manga
+
+/**
+ * When a backup is restored over a manga that already has chapters, per-chapter read state must merge
+ * rather than overwrite: a chapter read on either side stays read, and locally-recorded reading
+ * progress is preserved when the backup hasn't progressed. Losing this silently rewinds a user's
+ * progress, so it's a high data-loss-risk path.
+ *
+ * The update happens inside a suspend transaction, run inline here; the chapters update's read (arg 4)
+ * and last_page_read (arg 6) are captured.
+ */
+class MangaRestoreChaptersTest {
+
+    private val mangaId = 7L
+
+    /** Restores [backup] over [dbChapters] and returns (read, lastPageRead) of the single chapter update. */
+    private suspend fun restoredChapterUpdate(
+        backup: BackupChapter,
+        dbChapter: Chapter,
+    ): Pair<Boolean?, Long?> {
+        val updates = mutableListOf<Pair<Boolean?, Long?>>()
+        val database = mockk<Database>(relaxed = true) {
+            coEvery { transaction(any(), any()) } coAnswers {
+                secondArg<suspend SuspendingTransactionWithoutReturn.() -> Unit>().invoke(mockk(relaxed = true))
+            }
+            coEvery {
+                chaptersQueries.update(
+                    any(), any(), any(), any(), any(), any(), any(), any(),
+                    any(), any(), any(), any(), any(), any(), any(),
+                )
+            } coAnswers {
+                updates.add(arg<Boolean?>(4) to arg<Long?>(6))
+                0L
+            }
+        }
+        val dbManga = Manga.create().copy(id = mangaId, url = "u", source = 1L)
+        val restorer = MangaRestorer(
+            database = database,
+            getCategories = mockk { coEvery { await() } returns emptyList() },
+            getMangaByUrlAndSourceId = mockk<GetMangaByUrlAndSourceId> {
+                coEvery { await("u", 1L) } returns dbManga
+            },
+            getChaptersByMangaId = mockk<GetChaptersByMangaId> {
+                coEvery { await(mangaId) } returns listOf(dbChapter)
+            },
+            updateManga = mockk(relaxed = true),
+            getTracks = mockk(relaxed = true),
+            insertTrack = mockk(relaxed = true),
+            fetchInterval = mockk(relaxed = true),
+            reikaiLibraryPreferences = mockk(relaxed = true),
+            mangaMetadataRepository = mockk(relaxed = true),
+        )
+
+        restorer.restore(BackupManga(source = 1L, url = "u", title = "T", chapters = listOf(backup)), emptyList())
+        return updates.single()
+    }
+
+    @Test
+    fun `a chapter read locally stays read even when the backup has it unread`() = runTest {
+        val backup = BackupChapter(url = "c1", name = "C1", read = false, lastPageRead = 0)
+        val dbChapter = Chapter.create().copy(id = 1, mangaId = mangaId, url = "c1", name = "C1", read = true, lastPageRead = 50)
+
+        restoredChapterUpdate(backup, dbChapter).first shouldBe true
+    }
+
+    @Test
+    fun `local reading progress is kept when the backup chapter has not progressed`() = runTest {
+        val backup = BackupChapter(url = "c1", name = "C1", read = false, lastPageRead = 0)
+        val dbChapter = Chapter.create().copy(id = 1, mangaId = mangaId, url = "c1", name = "C1", read = false, lastPageRead = 30)
+
+        restoredChapterUpdate(backup, dbChapter).second shouldBe 30L
+    }
+}

--- a/app/src/test/java/exh/util/ThrottleManagerTest.kt
+++ b/app/src/test/java/exh/util/ThrottleManagerTest.kt
@@ -1,0 +1,53 @@
+package exh.util
+
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+
+/**
+ * The favorite-write throttle spaces successive requests further apart (instant, then +inc each call)
+ * up to a ceiling. Freezing the clock at zero isolates that escalation: each call's delay is exactly
+ * the accumulated throttle time, which runTest's virtual clock advances and we read back.
+ */
+class ThrottleManagerTest {
+
+    private fun manager() = ThrottleManager(
+        max = 60.milliseconds,
+        inc = 20.milliseconds,
+        now = { Duration.ZERO },
+    )
+
+    @Test
+    fun `the first throttle does not delay`() = runTest {
+        manager().throttle()
+
+        testScheduler.currentTime shouldBe 0L
+    }
+
+    @Test
+    fun `successive throttles escalate the delay by the increment`() = runTest {
+        val throttle = manager()
+
+        throttle.throttle() // +0ms
+        throttle.throttle() // +20ms
+        throttle.throttle() // +40ms
+
+        testScheduler.currentTime shouldBe 60L
+    }
+
+    @Test
+    fun `the escalating delay is capped at the maximum`() = runTest {
+        val throttle = manager()
+        throttle.throttle() // +0ms
+        throttle.throttle() // +20ms
+        throttle.throttle() // +40ms
+        throttle.throttle() // +60ms (throttle time now at the 60ms ceiling)
+        val beforeCapped = testScheduler.currentTime
+
+        throttle.throttle()
+
+        testScheduler.currentTime - beforeCapped shouldBe 60L
+    }
+}

--- a/app/src/test/java/reikai/data/novel/NovelChapterSyncTest.kt
+++ b/app/src/test/java/reikai/data/novel/NovelChapterSyncTest.kt
@@ -1,0 +1,143 @@
+package reikai.data.novel
+
+import app.cash.sqldelight.SuspendingTransactionWithoutReturn
+import app.cash.sqldelight.async.coroutines.awaitAsOne
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import reikai.domain.novel.NovelChapterRepository
+import reikai.domain.novel.NovelRepository
+import reikai.domain.novel.model.Novel
+import reikai.domain.novel.model.NovelChapter
+import reikai.novel.host.ChapterItem
+import tachiyomi.data.Database
+
+/**
+ * Reconciliation of a freshly-parsed novel chapter list against the stored rows. Covers the three
+ * behaviours a reader would notice if they broke: a re-added chapter (same number, new url) keeps its
+ * read/bookmark state instead of resurfacing as unread; trailing-slash url variants are treated as
+ * distinct (exact-match dedup only); and fetch dates stagger so list order stays stable.
+ *
+ * The writes happen inside a suspend `database.transaction`, so the test runs that body inline and
+ * captures the insert arguments; selectLastInsertedRowId().awaitAsOne() is stubbed via the async
+ * extension facade.
+ */
+class NovelChapterSyncTest {
+
+    private data class InsertedRow(val url: String, val read: Boolean, val bookmark: Boolean, val dateFetch: Long)
+
+    @AfterEach
+    fun tearDown() = unmockkAll()
+
+    private fun dbChapter(
+        url: String,
+        number: Double,
+        read: Boolean = false,
+        bookmark: Boolean = false,
+        dateFetch: Long = 0L,
+        id: Long = 1L,
+    ) = NovelChapter(
+        id = id, novelId = 1L, url = url, name = "name", read = read, bookmark = bookmark,
+        lastTextProgress = 0L, chapterNumber = number, sourceOrder = 0L, dateFetch = dateFetch,
+        dateUpload = 0L, page = "", isDownloaded = false,
+    )
+
+    private fun srcItem(url: String, number: Double) =
+        ChapterItem(name = "name", path = url, chapterNumber = number)
+
+    private class Synced(
+        val result: Pair<List<NovelChapter>, List<NovelChapter>>,
+        val inserted: List<InsertedRow>,
+    )
+
+    private suspend fun sync(db: List<NovelChapter>, source: List<ChapterItem>): Synced {
+        mockkStatic("app.cash.sqldelight.async.coroutines.QueryExtensionsKt")
+        val inserted = mutableListOf<InsertedRow>()
+        val database = mockk<Database>(relaxed = true) {
+            coEvery { transaction(any(), any()) } coAnswers {
+                secondArg<suspend SuspendingTransactionWithoutReturn.() -> Unit>().invoke(mockk(relaxed = true))
+            }
+            coEvery {
+                novel_chaptersQueries.insert(
+                    any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
+                )
+            } coAnswers {
+                inserted.add(InsertedRow(url = arg(1), read = arg(3), bookmark = arg(4), dateFetch = arg(8)))
+                0L
+            }
+            coEvery { novel_chaptersQueries.selectLastInsertedRowId().awaitAsOne() } returns 100L
+        }
+        val novelChapterRepository = mockk<NovelChapterRepository>(relaxed = true) {
+            coEvery { getByNovelId(1L) } returns db
+        }
+        val novelRepository = mockk<NovelRepository>(relaxed = true)
+        val novel = Novel.create().copy(id = 1L, title = "Test")
+
+        val result = syncChaptersWithNovelSource(source, novel, novelChapterRepository, novelRepository, database)
+        return Synced(result, inserted)
+    }
+
+    @Test
+    fun `a re-added chapter inherits the deleted twin's read and bookmark state`() = runTest {
+        val db = listOf(dbChapter("/c/5-old", number = 5.0, read = true, bookmark = true))
+        val source = listOf(srcItem("/c/5-new", number = 5.0))
+
+        val row = sync(db, source).inserted.single()
+
+        (row.read to row.bookmark) shouldBe (true to true)
+    }
+
+    @Test
+    fun `a re-added chapter reuses the deleted twin's fetch date`() = runTest {
+        val db = listOf(dbChapter("/c/5-old", number = 5.0, read = true, dateFetch = 1000L))
+        val source = listOf(srcItem("/c/5-new", number = 5.0))
+
+        sync(db, source).inserted.single().dateFetch shouldBe 1000L
+    }
+
+    @Test
+    fun `a re-added chapter does not resurface as new`() = runTest {
+        val db = listOf(dbChapter("/c/5-old", number = 5.0, read = true))
+        val source = listOf(srcItem("/c/5-new", number = 5.0))
+
+        sync(db, source).result.first shouldBe emptyList()
+    }
+
+    @Test
+    fun `a genuinely new chapter surfaces as new`() = runTest {
+        val source = listOf(srcItem("/c/1", number = 1.0))
+
+        sync(emptyList(), source).result.first.map { it.url } shouldBe listOf("/c/1")
+    }
+
+    @Test
+    fun `a genuinely new chapter is inserted unread`() = runTest {
+        val source = listOf(srcItem("/c/1", number = 1.0))
+
+        sync(emptyList(), source).inserted.single().read shouldBe false
+    }
+
+    @Test
+    fun `trailing-slash url variants are kept as distinct chapters`() = runTest {
+        // Dedup is exact-string, so "/c/5" and "/c/5/" are two chapters, not one.
+        val source = listOf(srcItem("/c/5", number = 5.0), srcItem("/c/5/", number = 5.0))
+
+        sync(emptyList(), source).inserted.map { it.url } shouldContainExactlyInAnyOrder listOf("/c/5", "/c/5/")
+    }
+
+    @Test
+    fun `fetch dates stagger strictly downward in source order`() = runTest {
+        // Sources return newest-first, so earlier rows get the higher date_fetch to preserve order.
+        val source = listOf(srcItem("/c/3", 3.0), srcItem("/c/2", 2.0), srcItem("/c/1", 1.0))
+
+        val dates = sync(emptyList(), source).inserted.map { it.dateFetch }
+
+        dates.zipWithNext().all { (a, b) -> a > b } shouldBe true
+    }
+}

--- a/app/src/test/java/reikai/domain/recommendation/RecommendationRankerTest.kt
+++ b/app/src/test/java/reikai/domain/recommendation/RecommendationRankerTest.kt
@@ -1,6 +1,7 @@
 package reikai.domain.recommendation
 
 import eu.kanade.tachiyomi.source.model.SManga
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
 import reikai.domain.recommendation.taste.TasteProfile
@@ -36,5 +37,19 @@ class RecommendationRankerTest {
         val ranked = ranker.rank(pool, TasteProfile.EMPTY, agreement)
 
         ranked.map { it.manga.url } shouldBe listOf("/a", "/b")
+    }
+
+    @Test
+    fun `a zero agreement count does not corrupt the taste-scored ranking`() {
+        // With a real taste profile the scoring path runs ln(agreement); a 0 count yields -Infinity,
+        // not NaN, so the sort stays well-ordered and keeps every candidate instead of dropping one.
+        val ranker = RecommendationRanker()
+        val taste = TasteProfile(tagScores = mapOf("action" to 0.5), tagEntryCounts = mapOf("action" to 1), totalEntries = 1)
+        val pool = listOf(candidate("/a", "A"), candidate("/b", "B"))
+        val agreement = mapOf("/a" to 1, "/b" to 0)
+
+        val ranked = ranker.rank(pool, taste, agreement)
+
+        ranked.map { it.manga.url } shouldContainExactlyInAnyOrder listOf("/a", "/b")
     }
 }

--- a/app/src/test/java/reikai/novel/host/LnHostBridgeTest.kt
+++ b/app/src/test/java/reikai/novel/host/LnHostBridgeTest.kt
@@ -1,0 +1,34 @@
+package reikai.novel.host
+
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+
+/**
+ * Plugins hand the host a JSON `FetchInit`. When strict decoding fails (a field has a shape the
+ * serializer rejects), the bridge falls back to picking out the fields it understands rather than
+ * aborting the whole fetch. These pin that lenient fallback.
+ */
+class LnHostBridgeTest {
+
+    private val bridge = LnHostBridge(preferenceStore = mockk(relaxed = true), client = mockk(relaxed = true))
+
+    @Test
+    fun `blank options decode to defaults`() {
+        bridge.parseFetchOpts("") shouldBe LnHostBridge.FetchOpts()
+    }
+
+    @Test
+    fun `well-formed options keep their headers`() {
+        bridge.parseFetchOpts("""{"method":"GET","headers":{"A":"1"}}""").headers shouldBe mapOf("A" to "1")
+    }
+
+    @Test
+    fun `a malformed headers shape drops headers but keeps method and body`() {
+        // headers is an array, not an object, so strict decode fails and the manual fallback runs:
+        // the bad headers become null while method and body survive.
+        val opts = bridge.parseFetchOpts("""{"method":"POST","headers":["bad"],"body":"data"}""")
+
+        Triple(opts.method, opts.headers, opts.body) shouldBe Triple("POST", null, "data")
+    }
+}

--- a/app/src/test/java/reikai/novel/update/LnPluginVersionTest.kt
+++ b/app/src/test/java/reikai/novel/update/LnPluginVersionTest.kt
@@ -48,4 +48,16 @@ class LnPluginVersionTest {
     fun `major bump outranks minor or patch`() {
         assertTrue(LnPluginVersion.compare("2.0.0", "1.99.99") > 0)
     }
+
+    @Test
+    fun `a non-numeric segment falls back to string compare without crashing`() {
+        // "2.x" survives the digit/dot filter as "2." -> the empty segment can't parse, so the
+        // comparison degrades to a raw string compare ('x' > '0') instead of throwing.
+        assertTrue(LnPluginVersion.compare("2.x", "2.0") > 0)
+    }
+
+    @Test
+    fun `the non-numeric fallback is symmetric`() {
+        assertTrue(LnPluginVersion.compare("2.0", "2.x") < 0)
+    }
 }

--- a/app/src/test/java/reikai/presentation/library/ReikaiDynamicCategoryTest.kt
+++ b/app/src/test/java/reikai/presentation/library/ReikaiDynamicCategoryTest.kt
@@ -1,0 +1,73 @@
+package reikai.presentation.library
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import tachiyomi.domain.category.model.Category
+
+/**
+ * A synthetic dynamic-grouping category packs its metadata into [Category.name] (a real DB category
+ * can't carry sourceId/langId). These cover the encode -> decode contract the grouping relies on:
+ * names are built exactly as LibraryDynamicGrouping builds them ("display SPLITTER id" for sources,
+ * "code SPLITTER display" for languages).
+ */
+class ReikaiDynamicCategoryTest {
+
+    private fun dynamic(name: String) = Category(id = -2, name = name, order = 0, flags = 0)
+
+    private fun sourceName(display: String, sourceId: Long) =
+        "$display${ReikaiDynamicCategory.SOURCE_SPLITTER}$sourceId"
+
+    private fun langName(code: String, display: String) =
+        "$code${ReikaiDynamicCategory.LANG_SPLITTER}$display"
+
+    @Test
+    fun `a negative id marks a synthetic category`() {
+        ReikaiDynamicCategory.isDynamic(dynamic("anything")) shouldBe true
+    }
+
+    @Test
+    fun `a non-negative id is a real category`() {
+        ReikaiDynamicCategory.isDynamic(Category(id = 3, name = "Reading", order = 0, flags = 0)) shouldBe false
+    }
+
+    @Test
+    fun `source group decodes its display name`() {
+        ReikaiDynamicCategory.displayName(dynamic(sourceName("MangaDex", 5))) shouldBe "MangaDex"
+    }
+
+    @Test
+    fun `source group decodes its source id`() {
+        ReikaiDynamicCategory.sourceId(dynamic(sourceName("MangaDex", 5))) shouldBe 5L
+    }
+
+    @Test
+    fun `source group has no language id`() {
+        ReikaiDynamicCategory.langId(dynamic(sourceName("MangaDex", 5))) shouldBe null
+    }
+
+    @Test
+    fun `language group decodes its display name`() {
+        ReikaiDynamicCategory.displayName(dynamic(langName("en", "English"))) shouldBe "English"
+    }
+
+    @Test
+    fun `language group decodes its language code`() {
+        ReikaiDynamicCategory.langId(dynamic(langName("en", "English"))) shouldBe "en"
+    }
+
+    @Test
+    fun `language group has no source id`() {
+        ReikaiDynamicCategory.sourceId(dynamic(langName("en", "English"))) shouldBe null
+    }
+
+    @Test
+    fun `a plain name decodes to itself`() {
+        ReikaiDynamicCategory.displayName(dynamic("Favorites")) shouldBe "Favorites"
+    }
+
+    @Test
+    fun `the encoded name is the stable collapse key`() {
+        val name = sourceName("MangaDex", 5)
+        ReikaiDynamicCategory.headerKey(dynamic(name)) shouldBe name
+    }
+}

--- a/core/common/src/main/kotlin/eu/kanade/tachiyomi/network/AndroidCookieJar.kt
+++ b/core/common/src/main/kotlin/eu/kanade/tachiyomi/network/AndroidCookieJar.kt
@@ -42,7 +42,8 @@ class AndroidCookieJar : CookieJar {
         }
 
         return cookies.split(";")
-            .map { it.substringBefore("=") }
+            // RK: trim so non-first cookies (" b=2") match the name filter
+            .map { it.substringBefore("=").trim() }
             .filterNames()
             .onEach { manager.setCookie(urlString, "$it=;Max-Age=$maxAge") }
             .count()

--- a/core/common/src/main/kotlin/eu/kanade/tachiyomi/network/interceptor/FlareSolverrClient.kt
+++ b/core/common/src/main/kotlin/eu/kanade/tachiyomi/network/interceptor/FlareSolverrClient.kt
@@ -312,7 +312,8 @@ private data class FlareSolverrSolution(
 )
 
 @Serializable
-private data class FlareSolverrCookie(
+// RK: internal (was private) so toRawCookieString's leading-dot domain logic is unit-testable.
+internal data class FlareSolverrCookie(
     val name: String,
     val value: String,
     val domain: String = "",

--- a/core/common/src/test/java/eu/kanade/tachiyomi/network/AndroidCookieJarTest.kt
+++ b/core/common/src/test/java/eu/kanade/tachiyomi/network/AndroidCookieJarTest.kt
@@ -1,0 +1,73 @@
+package eu.kanade.tachiyomi.network
+
+import android.webkit.CookieManager
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.verify
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class AndroidCookieJarTest {
+
+    private val url = "https://example.com/".toHttpUrl()
+    private lateinit var manager: CookieManager
+
+    @BeforeEach
+    fun setUp() {
+        // AndroidCookieJar grabs the singleton in its field initializer, so the static mock
+        // has to be in place before the jar is constructed.
+        mockkStatic(CookieManager::class)
+        manager = mockk(relaxed = true)
+        every { CookieManager.getInstance() } returns manager
+    }
+
+    @AfterEach
+    fun tearDown() {
+        io.mockk.unmockkStatic(CookieManager::class)
+    }
+
+    @Test
+    fun `targeted removal matches a non-first cookie despite the leading space`() {
+        // The split on ";" leaves " b=2" with a leading space; without trimming, the name " b"
+        // never matched the "b" filter and the cookie was silently kept.
+        every { manager.getCookie(any()) } returns "a=1; b=2"
+        val expired = slot<String>()
+        every { manager.setCookie(any(), capture(expired)) } returns Unit
+
+        AndroidCookieJar().remove(url, cookieNames = listOf("b"))
+
+        expired.captured shouldBe "b=;Max-Age=-1"
+    }
+
+    @Test
+    fun `targeted removal expires only the named cookie`() {
+        every { manager.getCookie(any()) } returns "a=1; b=2"
+
+        val cleared = AndroidCookieJar().remove(url, cookieNames = listOf("b"))
+
+        cleared shouldBe 1
+    }
+
+    @Test
+    fun `targeted removal leaves an unnamed first cookie untouched`() {
+        every { manager.getCookie(any()) } returns "a=1; b=2"
+
+        AndroidCookieJar().remove(url, cookieNames = listOf("b"))
+
+        verify(exactly = 0) { manager.setCookie(any(), "a=;Max-Age=-1") }
+    }
+
+    @Test
+    fun `removal without a name filter expires every cookie`() {
+        every { manager.getCookie(any()) } returns "a=1; b=2"
+
+        val cleared = AndroidCookieJar().remove(url)
+
+        cleared shouldBe 2
+    }
+}

--- a/core/common/src/test/java/eu/kanade/tachiyomi/network/interceptor/FlareSolverrCookieTest.kt
+++ b/core/common/src/test/java/eu/kanade/tachiyomi/network/interceptor/FlareSolverrCookieTest.kt
@@ -1,0 +1,29 @@
+package eu.kanade.tachiyomi.network.interceptor
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+/**
+ * FlareSolverr returns cookies whose domain may be blank, bare, or already dotted. They're handed to
+ * Android's CookieManager, which only treats a cookie as a domain cookie (matching the apex and all
+ * subdomains) when the domain has a leading dot. These pin that normalization.
+ */
+class FlareSolverrCookieTest {
+
+    private fun cookie(domain: String) = FlareSolverrCookie(name = "n", value = "v", domain = domain)
+
+    @Test
+    fun `a blank domain falls back to the request host with a leading dot`() {
+        cookie(domain = "").toRawCookieString("example.com") shouldBe "n=v; Domain=.example.com; Path=/"
+    }
+
+    @Test
+    fun `an already-dotted domain is left as-is`() {
+        cookie(domain = ".foo.com").toRawCookieString("example.com") shouldBe "n=v; Domain=.foo.com; Path=/"
+    }
+
+    @Test
+    fun `a bare domain gains a leading dot`() {
+        cookie(domain = "foo.com").toRawCookieString("example.com") shouldBe "n=v; Domain=.foo.com; Path=/"
+    }
+}

--- a/domain/src/test/java/exh/metadata/MetadataParsingTest.kt
+++ b/domain/src/test/java/exh/metadata/MetadataParsingTest.kt
@@ -1,0 +1,60 @@
+package exh.metadata
+
+import exh.metadata.metadata.EHentaiSearchMetadata
+import exh.metadata.metadata.NHentaiSearchMetadata
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+/**
+ * Pure parsing helpers behind the gallery sources: byte-size strings (used for the size badge) and
+ * the id/token extraction the EH/NH metadata pipeline relies on. The full-URL branch of the EH
+ * parser goes through android.net.Uri, so these cover only the path-only branch (pure JVM).
+ */
+class MetadataParsingTest {
+
+    @Test
+    fun `parses gibibytes against the 1024 base`() {
+        MetadataUtil.parseHumanReadableByteCount("1.0 GiB") shouldBe 1073741824.0
+    }
+
+    @Test
+    fun `parses gigabytes against the 1000 base`() {
+        MetadataUtil.parseHumanReadableByteCount("1.0 GB") shouldBe 1.0E9
+    }
+
+    @Test
+    fun `returns null for an unrecognized unit`() {
+        MetadataUtil.parseHumanReadableByteCount("1.0 XB") shouldBe null
+    }
+
+    @Test
+    fun `throws when the size has no numeric prefix`() {
+        shouldThrow<NumberFormatException> { MetadataUtil.parseHumanReadableByteCount("bad") }
+    }
+
+    @Test
+    fun `reads the gallery id from a path url`() {
+        EHentaiSearchMetadata.galleryId("/g/123/abc/") shouldBe "123"
+    }
+
+    @Test
+    fun `reads the gallery token from a path url`() {
+        EHentaiSearchMetadata.galleryToken("/g/123/abc/") shouldBe "abc"
+    }
+
+    @Test
+    fun `normalizes a path url to the canonical id and token form`() {
+        EHentaiSearchMetadata.normalizeUrl("/g/123/abc/") shouldBe "/g/123/abc/?nw=always"
+    }
+
+    @Test
+    fun `reads the nhentai id from a trailing-slash url`() {
+        NHentaiSearchMetadata.nhUrlToId("/g/456/") shouldBe 456L
+    }
+
+    @Test
+    fun `round-trips an nhentai id through path and back`() {
+        NHentaiSearchMetadata.nhUrlToId(NHentaiSearchMetadata.nhIdToPath(789)) shouldBe 789L
+    }
+}


### PR DESCRIPTION
## Summary

Fills the highest-value unit-test gaps left after the v0.1.0 cut, fixes two latent bugs found along the way, and gates CI on the unit tests.

## Tests added

**Backup restore** (the highest data-loss risk):
- Manga category remap on restore: a backup's category order maps through the backup's names to this device's category ids, and a name with no local match is dropped rather than mis-assigned.
- Chapter read-state merge on restore: a chapter read on either side stays read, and local reading progress is kept when the backup chapter hasn't moved.

**Novels:**
- Novel chapter reconciliation: a re-added chapter keeps its read/bookmark state and fetch date, trailing-slash url variants stay distinct, and fetch dates stagger to preserve list order.
- LN plugin version non-numeric fallback; LN host fetch-options lenient parse (a malformed field no longer aborts the whole request).

**Other areas:**
- EH/NH gallery metadata parsing, dynamic-category name encode/decode, recommendation ranking zero-agreement guard, EXH throttle escalation and ceiling, FlareSolverr cookie-domain normalization, and cookie-jar targeted removal.

## Fixes

- `AndroidCookieJar.remove` now trims cookie names, so targeted removal matches cookies after the first one (latent: no caller passes names today, but it is a public helper).
- `ExtensionLoader` no longer logs a `ClassCastException` with a full stack trace for every installed extension at startup. The platform stores the extension lib version as a float, so reading it as a Double always failed and silently fell back to the versionName-derived value; it is now derived directly (matches Komikku).

## CI

- `build_check`, `preview`, and `release` builds now gate on the unit test task.

## Under the hood

- The restore/novel-sync tests drive SQLDelight's suspend `database.transaction { }` inline and capture the query arguments. Three production members were bumped from `private` to `internal` (one `// RK`-marked in a Mihon file) so their logic is reachable from tests; `ThrottleManager` gained a defaulted clock seam.

Verified: full `test` suite green, and the minified `:app:assemblePreview` (R8) build assembles cleanly.
