### PR TITLE
feat(novel): add light novels to the Browse migrate tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Reikai uses its own [Semantic Versioning](https://semver.org/) from the Mihon-ba
 
 ## [Unreleased]
 
+### Additions
+
+- **Migrate light novels from Browse → Migration.** The Migration tab now has the same All / Manga / Novels switch as the rest of Browse: pick a novel source to see its saved novels, select the ones to move, and run them through the existing novel migration flow. A source still shows (with its last-known name and icon) even after its plugin is uninstalled, so you can always migrate away from it.
+
 ## [0.1.1]
 
 ### Other

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/BrowseTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/BrowseTab.kt
@@ -17,12 +17,12 @@ import eu.kanade.presentation.components.TabbedScreen
 import eu.kanade.presentation.util.Tab
 import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.ui.browse.extension.ExtensionsScreenModel
-import eu.kanade.tachiyomi.ui.browse.migration.sources.migrateSourceTab
 import eu.kanade.tachiyomi.ui.browse.source.globalsearch.GlobalSearchScreen
 import eu.kanade.tachiyomi.ui.main.MainActivity
 // RK -->
 import reikai.presentation.browse.ReikaiBrowseScreenModel
 import reikai.presentation.browse.extension.reikaiExtensionsTab
+import reikai.presentation.browse.migrate.reikaiMigrateSourceTab
 import reikai.presentation.browse.source.reikaiSourcesTab
 // RK <--
 import kotlinx.coroutines.channels.BufferOverflow
@@ -70,7 +70,8 @@ data object BrowseTab : Tab {
             // RK: chip-switched manga + light-novel sources / extensions (P5 S3a).
             reikaiSourcesTab(browseScreenModel),
             reikaiExtensionsTab(extensionsScreenModel, browseScreenModel),
-            migrateSourceTab(),
+            // RK: chip-switched manga + light-novel migrate-source list.
+            reikaiMigrateSourceTab(browseScreenModel),
         )
 
         val state = rememberPagerState { tabs.size }

--- a/app/src/main/java/reikai/domain/novel/LnSourceIdentity.kt
+++ b/app/src/main/java/reikai/domain/novel/LnSourceIdentity.kt
@@ -1,0 +1,18 @@
+package reikai.domain.novel
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Last-known display identity for a light-novel source, persisted in [NovelPreferences.seenNovelSources]
+ * keyed by the plugin id. Written whenever a source is loaded/installed and never pruned on uninstall,
+ * so a favorited novel whose plugin was later removed still resolves to a real name + icon in the
+ * Browse migration list (the novel twin of manga's persisted stub-source name table). When even this
+ * cache misses (a source never installed on this device, e.g. a backup restore), callers fall back to
+ * the raw plugin id.
+ */
+@Serializable
+data class LnSourceIdentity(
+    val name: String,
+    val iconUrl: String? = null,
+    val lang: String? = null,
+)

--- a/app/src/main/java/reikai/domain/novel/NovelPreferences.kt
+++ b/app/src/main/java/reikai/domain/novel/NovelPreferences.kt
@@ -37,6 +37,21 @@ class NovelPreferences(
         },
     )
 
+    /**
+     * Last-known display identity (name, icon, lang) per plugin id, kept so the Browse migration list
+     * can render a source whose plugin is no longer installed (manga-stub parity). Written on every
+     * source load/install and deliberately NOT pruned on uninstall, so the row survives removal. A
+     * source never seen on this device (e.g. a backup restore) is absent and falls back to its raw id.
+     */
+    fun seenNovelSources() = preferenceStore.getObjectFromString(
+        key = "ln_seen_novel_sources",
+        defaultValue = emptyMap(),
+        serializer = { metadataJson.encodeToString(seenSourcesMapSerializer, it) },
+        deserializer = {
+            runCatching { metadataJson.decodeFromString(seenSourcesMapSerializer, it) }.getOrElse { emptyMap() }
+        },
+    )
+
     /** Most recently tapped LN source id (drives the Last Used section on the sources list). */
     fun lastUsedNovelSource() = preferenceStore.getString("last_used_novel_source", "")
 
@@ -272,6 +287,8 @@ class NovelPreferences(
     companion object {
         private val metadataMapSerializer =
             MapSerializer(String.serializer(), LnInstalledPluginMetadata.serializer())
+        private val seenSourcesMapSerializer =
+            MapSerializer(String.serializer(), LnSourceIdentity.serializer())
         private val metadataJson = Json { ignoreUnknownKeys = true }
     }
 }

--- a/app/src/main/java/reikai/novel/install/LnPluginInstaller.kt
+++ b/app/src/main/java/reikai/novel/install/LnPluginInstaller.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.withContext
 import logcat.LogPriority
 import okhttp3.Request
 import reikai.domain.novel.LnInstalledPluginMetadata
+import reikai.domain.novel.LnSourceIdentity
 import reikai.domain.novel.NovelPreferences
 import reikai.novel.host.LnPluginHost
 import reikai.novel.host.LnPluginLoader
@@ -66,6 +67,7 @@ class LnPluginInstaller(
         val info = host.loadPlugin(scopeIdFromUrl(canonical), src, metadata?.iconUrl, metadata?.lang)
         val source = LnPluginSource(host, info)
         manager.register(source)
+        rememberSeenSources(listOf(source))
 
         // A plugin's identity is [info.id], not its URL. Drop any prior install of the same plugin (the
         // same plugin from a different/old repo, or a URL carried in by a restore) so installing
@@ -127,7 +129,23 @@ class LnPluginInstaller(
         // Record successes on the single (mutex-holding) coroutine, after awaitAll, to avoid racing on
         // loadedUrls from the parallel children.
         loadedUrls += ok.map { it.first }
+        rememberSeenSources(ok.map { it.second })
         return ok.map { it.second }
+    }
+
+    /**
+     * Cache each loaded source's display identity (name / icon / lang) by plugin id, so the Browse
+     * migration list can render a source even after its plugin is uninstalled. Merged in (an install
+     * refreshes a renamed source) and never pruned by [uninstall], which is what makes the stub row
+     * survive removal.
+     */
+    private fun rememberSeenSources(sources: List<LnPluginSource>) {
+        if (sources.isEmpty()) return
+        val current = prefs.seenNovelSources().get()
+        val updated = current + sources.associate {
+            it.id to LnSourceIdentity(name = it.name, iconUrl = it.iconUrl, lang = it.lang)
+        }
+        if (updated != current) prefs.seenNovelSources().set(updated)
     }
 
     /**

--- a/app/src/main/java/reikai/presentation/browse/migrate/MigrateNovelScreen.kt
+++ b/app/src/main/java/reikai/presentation/browse/migrate/MigrateNovelScreen.kt
@@ -1,0 +1,215 @@
+package reikai.presentation.browse.migrate
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.ArrowForward
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SmallExtendedFloatingActionButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.animateFloatingActionButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import cafe.adriel.voyager.core.model.StateScreenModel
+import cafe.adriel.voyager.core.model.rememberScreenModel
+import cafe.adriel.voyager.core.model.screenModelScope
+import cafe.adriel.voyager.navigator.LocalNavigator
+import cafe.adriel.voyager.navigator.currentOrThrow
+import eu.kanade.presentation.components.AppBar
+import eu.kanade.presentation.manga.components.MangaCover
+import eu.kanade.presentation.util.Screen
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.update
+import reikai.data.coil.NovelCover
+import reikai.domain.novel.NovelPreferences
+import reikai.domain.novel.NovelRepository
+import reikai.domain.novel.model.Novel
+import reikai.novel.source.NovelSourceManager
+import reikai.presentation.novel.details.NovelScreen
+import reikai.presentation.novel.migrate.NovelMigrationConfigScreen
+import tachiyomi.i18n.MR
+import tachiyomi.presentation.core.components.FastScrollLazyColumn
+import tachiyomi.presentation.core.components.material.Scaffold
+import tachiyomi.presentation.core.components.material.padding
+import tachiyomi.presentation.core.i18n.stringResource
+import tachiyomi.presentation.core.screens.EmptyScreen
+import tachiyomi.presentation.core.screens.LoadingScreen
+import tachiyomi.presentation.core.util.selectedBackground
+import tachiyomi.presentation.core.util.shouldExpandFAB
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+
+/**
+ * Per-source favorited-novel picker, the novel twin of
+ * [eu.kanade.tachiyomi.ui.browse.migration.manga.MigrateMangaScreen]: lists the favorited novels of
+ * one source, multi-select, then Continue hands the selection to the existing
+ * [NovelMigrationSourcePickScreen] pipeline. Works for an uninstalled source too, since the list and
+ * the migration read stored data.
+ */
+data class MigrateNovelScreen(
+    private val sourceId: String,
+) : Screen() {
+
+    @Composable
+    override fun Content() {
+        val navigator = LocalNavigator.currentOrThrow
+        val screenModel = rememberScreenModel { MigrateNovelScreenModel(sourceId) }
+        val state by screenModel.state.collectAsState()
+
+        if (state.loading) {
+            LoadingScreen()
+            return
+        }
+
+        BackHandler(enabled = state.selectionMode) { screenModel.clearSelection() }
+
+        val lazyListState = rememberLazyListState()
+
+        Scaffold(
+            topBar = { scrollBehavior ->
+                AppBar(
+                    title = state.sourceName,
+                    navigateUp = {
+                        if (state.selectionMode) screenModel.clearSelection() else navigator.pop()
+                    },
+                    scrollBehavior = scrollBehavior,
+                )
+            },
+            floatingActionButton = {
+                SmallExtendedFloatingActionButton(
+                    text = { Text(text = stringResource(MR.strings.migrationConfigScreen_continueButtonText)) },
+                    icon = { Icon(imageVector = Icons.AutoMirrored.Outlined.ArrowForward, contentDescription = null) },
+                    onClick = {
+                        // Source-scoped: the user already picked novels from this one source, so go
+                        // straight to the migration config and skip the merge-group source picker (that
+                        // pre-step is for the library/details routes, where selection isn't per-source).
+                        val selection = state.selection.toList()
+                        screenModel.clearSelection()
+                        navigator.push(NovelMigrationConfigScreen(selection))
+                    },
+                    expanded = lazyListState.shouldExpandFAB(),
+                    modifier = Modifier.animateFloatingActionButton(
+                        visible = state.selectionMode,
+                        alignment = Alignment.BottomEnd,
+                    ),
+                )
+            },
+        ) { contentPadding ->
+            if (state.isEmpty) {
+                EmptyScreen(stringRes = MR.strings.empty_screen, modifier = Modifier.padding(contentPadding))
+                return@Scaffold
+            }
+            FastScrollLazyColumn(state = lazyListState, contentPadding = contentPadding) {
+                items(items = state.novels, key = { it.id }) { novel ->
+                    MigrateNovelItem(
+                        novel = novel,
+                        site = state.sourceSite,
+                        isSelected = novel.id in state.selection,
+                        onClickItem = { screenModel.toggleSelection(novel.id) },
+                        onClickCover = { navigator.push(NovelScreen(novel.source, novel.url)) },
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun MigrateNovelItem(
+    novel: Novel,
+    site: String?,
+    isSelected: Boolean,
+    onClickItem: () -> Unit,
+    onClickCover: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .selectedBackground(isSelected)
+            .fillMaxWidth()
+            .clickable(onClick = onClickItem)
+            .padding(horizontal = MaterialTheme.padding.medium, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        MangaCover.Book(
+            data = NovelCover(
+                url = novel.thumbnailUrl,
+                site = site,
+                isNovelFavorite = false,
+                lastModified = novel.coverLastModified,
+                novelId = novel.id,
+            ),
+            modifier = Modifier.width(48.dp),
+            onClick = onClickCover,
+        )
+        Text(
+            text = novel.title,
+            modifier = Modifier.padding(start = 16.dp),
+            style = MaterialTheme.typography.bodyMedium,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+        )
+    }
+}
+
+class MigrateNovelScreenModel(
+    private val sourceId: String,
+    private val novelRepository: NovelRepository = Injekt.get(),
+    private val sourceManager: NovelSourceManager = Injekt.get(),
+    private val novelPreferences: NovelPreferences = Injekt.get(),
+) : StateScreenModel<MigrateNovelScreenModel.State>(State()) {
+
+    init {
+        val source = sourceManager.get(sourceId)
+        val name = source?.name
+            ?: novelPreferences.seenNovelSources().get()[sourceId]?.name
+            ?: sourceId
+        mutableState.update { it.copy(sourceName = name, sourceSite = source?.site) }
+
+        novelRepository.getLibraryNovelAsFlow()
+            .map { list ->
+                list.asSequence()
+                    .map { it.novel }
+                    .filter { it.source == sourceId }
+                    .sortedWith(compareBy(String.CASE_INSENSITIVE_ORDER) { it.title })
+                    .toList()
+            }
+            .onEach { novels -> mutableState.update { it.copy(novels = novels, loading = false) } }
+            .launchIn(screenModelScope)
+    }
+
+    fun toggleSelection(id: Long) {
+        mutableState.update {
+            it.copy(selection = if (id in it.selection) it.selection - id else it.selection + id)
+        }
+    }
+
+    fun clearSelection() {
+        mutableState.update { it.copy(selection = emptySet()) }
+    }
+
+    data class State(
+        val loading: Boolean = true,
+        val sourceName: String = "",
+        val sourceSite: String? = null,
+        val novels: List<Novel> = emptyList(),
+        val selection: Set<Long> = emptySet(),
+    ) {
+        val isEmpty: Boolean get() = novels.isEmpty()
+        val selectionMode: Boolean get() = selection.isNotEmpty()
+    }
+}

--- a/app/src/main/java/reikai/presentation/browse/migrate/MigrateNovelSourcesScreenModel.kt
+++ b/app/src/main/java/reikai/presentation/browse/migrate/MigrateNovelSourcesScreenModel.kt
@@ -1,0 +1,142 @@
+package reikai.presentation.browse.migrate
+
+import androidx.compose.runtime.Immutable
+import cafe.adriel.voyager.core.model.StateScreenModel
+import cafe.adriel.voyager.core.model.screenModelScope
+import eu.kanade.domain.source.interactor.SetMigrateSorting
+import eu.kanade.domain.source.service.SourcePreferences
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import reikai.domain.novel.LnSourceIdentity
+import reikai.domain.novel.NovelPreferences
+import reikai.domain.novel.NovelRepository
+import reikai.novel.source.NovelSourceManager
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+
+/**
+ * Novel side of the Browse migration source list: favorited novels grouped by their source, with a
+ * count per source, sorted by the same migration sort preference manga uses. A source's display name
+ * and icon resolve through a 3-step chain so a row shows even when its plugin is uninstalled (manga
+ * stub parity): the live installed source, else the last-known [NovelPreferences.seenNovelSources]
+ * cache, else the raw plugin id. Tapping a row opens [MigrateNovelScreen] for that source.
+ */
+class MigrateNovelSourcesScreenModel(
+    private val novelRepository: NovelRepository = Injekt.get(),
+    private val sourceManager: NovelSourceManager = Injekt.get(),
+    private val novelPreferences: NovelPreferences = Injekt.get(),
+    private val sourcePreferences: SourcePreferences = Injekt.get(),
+    private val setMigrateSorting: SetMigrateSorting = Injekt.get(),
+) : StateScreenModel<MigrateNovelSourcesScreenModel.State>(State()) {
+
+    init {
+        combine(
+            novelRepository.getLibraryNovelAsFlow(),
+            sourceManager.sources,
+            novelPreferences.seenNovelSources().changes(),
+            sourcePreferences.migrationSortingMode.changes(),
+            sourcePreferences.migrationSortingDirection.changes(),
+        ) { libraryNovels, installedSources, cached, mode, direction ->
+            val installed = installedSources.associate {
+                it.id to LnSourceIdentity(name = it.name, iconUrl = it.iconUrl, lang = it.lang)
+            }
+            val rows = buildNovelMigrateSources(
+                sourceIdsPerNovel = libraryNovels.map { it.novel.source },
+                installed = installed,
+                cached = cached,
+            )
+            State(
+                isLoading = false,
+                items = sortNovelMigrateSources(rows, mode, direction),
+                sortingMode = mode,
+                sortingDirection = direction,
+            )
+        }
+            .onEach { mutableState.value = it }
+            .launchIn(screenModelScope)
+    }
+
+    fun toggleSortingMode() {
+        with(state.value) {
+            val newMode = when (sortingMode) {
+                SetMigrateSorting.Mode.ALPHABETICAL -> SetMigrateSorting.Mode.TOTAL
+                SetMigrateSorting.Mode.TOTAL -> SetMigrateSorting.Mode.ALPHABETICAL
+            }
+            setMigrateSorting.await(newMode, sortingDirection)
+        }
+    }
+
+    fun toggleSortingDirection() {
+        with(state.value) {
+            val newDirection = when (sortingDirection) {
+                SetMigrateSorting.Direction.ASCENDING -> SetMigrateSorting.Direction.DESCENDING
+                SetMigrateSorting.Direction.DESCENDING -> SetMigrateSorting.Direction.ASCENDING
+            }
+            setMigrateSorting.await(sortingMode, newDirection)
+        }
+    }
+
+    @Immutable
+    data class State(
+        val isLoading: Boolean = true,
+        val items: List<NovelMigrateSource> = emptyList(),
+        val sortingMode: SetMigrateSorting.Mode = SetMigrateSorting.Mode.ALPHABETICAL,
+        val sortingDirection: SetMigrateSorting.Direction = SetMigrateSorting.Direction.ASCENDING,
+    ) {
+        val isEmpty = items.isEmpty()
+    }
+}
+
+/** One migrate-from row: a novel source with how many favorited novels it holds. [isInstalled] is
+ *  false for a stub (plugin uninstalled or never seen), which still migrates from its stored data. */
+@Immutable
+data class NovelMigrateSource(
+    val id: String,
+    val name: String,
+    val iconUrl: String?,
+    val lang: String,
+    val count: Int,
+    val isInstalled: Boolean,
+)
+
+/**
+ * Pure core: turn one source id per favorited novel into per-source rows with counts, resolving each
+ * id's display identity as installed -> cached -> raw id. [installed] are the currently registered
+ * sources; [cached] the last-known identities that survive an uninstall. A row with neither falls
+ * back to its plugin id as the name and a null icon (the row's icon slot renders a book placeholder).
+ */
+internal fun buildNovelMigrateSources(
+    sourceIdsPerNovel: List<String>,
+    installed: Map<String, LnSourceIdentity>,
+    cached: Map<String, LnSourceIdentity>,
+): List<NovelMigrateSource> {
+    return sourceIdsPerNovel.groupingBy { it }.eachCount().map { (id, count) ->
+        val identity = installed[id] ?: cached[id]
+        NovelMigrateSource(
+            id = id,
+            name = identity?.name ?: id,
+            iconUrl = identity?.iconUrl,
+            lang = identity?.lang.orEmpty(),
+            count = count,
+            isInstalled = id in installed,
+        )
+    }
+}
+
+/** Order the rows by the shared migration sort: alphabetically by name or by favorite count, in the
+ *  chosen direction. Kept separate from grouping so both stay independently testable. */
+internal fun sortNovelMigrateSources(
+    list: List<NovelMigrateSource>,
+    mode: SetMigrateSorting.Mode,
+    direction: SetMigrateSorting.Direction,
+): List<NovelMigrateSource> {
+    val base: Comparator<NovelMigrateSource> = when (mode) {
+        SetMigrateSorting.Mode.ALPHABETICAL -> compareBy(String.CASE_INSENSITIVE_ORDER) { it.name }
+        SetMigrateSorting.Mode.TOTAL -> compareBy { it.count }
+    }
+    return when (direction) {
+        SetMigrateSorting.Direction.ASCENDING -> list.sortedWith(base)
+        SetMigrateSorting.Direction.DESCENDING -> list.sortedWith(base.reversed())
+    }
+}

--- a/app/src/main/java/reikai/presentation/browse/migrate/ReikaiMigrateSourceTab.kt
+++ b/app/src/main/java/reikai/presentation/browse/migrate/ReikaiMigrateSourceTab.kt
@@ -1,0 +1,248 @@
+package reikai.presentation.browse.migrate
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.HelpOutline
+import androidx.compose.material.icons.outlined.ArrowDownward
+import androidx.compose.material.icons.outlined.ArrowUpward
+import androidx.compose.material.icons.outlined.Numbers
+import androidx.compose.material.icons.outlined.SortByAlpha
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalUriHandler
+import cafe.adriel.voyager.core.model.rememberScreenModel
+import cafe.adriel.voyager.core.screen.Screen
+import cafe.adriel.voyager.navigator.LocalNavigator
+import cafe.adriel.voyager.navigator.currentOrThrow
+import eu.kanade.domain.source.interactor.SetMigrateSorting
+import eu.kanade.presentation.browse.MigrateSourceScreen
+import eu.kanade.presentation.browse.components.BaseSourceItem
+import eu.kanade.presentation.components.AppBar
+import eu.kanade.presentation.components.TabContent
+import eu.kanade.tachiyomi.ui.browse.migration.manga.MigrateMangaScreen
+import eu.kanade.tachiyomi.ui.browse.migration.sources.MigrateSourceScreenModel
+import reikai.domain.library.ContentType
+import reikai.presentation.browse.ReikaiBrowseScreenModel
+import reikai.presentation.browse.components.BrowseSectionHeader
+import reikai.presentation.browse.components.NovelSourceRow
+import reikai.presentation.components.ContentTypeFilterChips
+import tachiyomi.domain.source.model.Source
+import tachiyomi.i18n.MR
+import tachiyomi.presentation.core.components.Badge
+import tachiyomi.presentation.core.components.BadgeGroup
+import tachiyomi.presentation.core.components.ScrollbarLazyColumn
+import tachiyomi.presentation.core.components.Scroller.STICKY_HEADER_KEY_PREFIX
+import tachiyomi.presentation.core.components.material.padding
+import tachiyomi.presentation.core.components.material.topSmallPaddingValues
+import tachiyomi.presentation.core.i18n.stringResource
+import tachiyomi.presentation.core.screens.EmptyScreen
+import tachiyomi.presentation.core.screens.LoadingScreen
+import tachiyomi.presentation.core.theme.header
+import tachiyomi.presentation.core.util.plus
+
+/**
+ * Reikai wrapper for the Browse "Migration" tab: the sticky content-type chip over Mihon's manga
+ * migrate-source list (reused verbatim) and a net-new novel migrate-source list. Manga and Novels
+ * each show their sources with a favorite count; All interleaves both under type headers. Swapped in
+ * for Mihon's `migrateSourceTab()` at the [eu.kanade.tachiyomi.ui.browse.BrowseTab] call site via a
+ * `// RK` island. Mirrors [reikai.presentation.browse.source.reikaiSourcesTab].
+ */
+@Composable
+fun Screen.reikaiMigrateSourceTab(browseScreenModel: ReikaiBrowseScreenModel): TabContent {
+    val uriHandler = LocalUriHandler.current
+    val navigator = LocalNavigator.currentOrThrow
+    val mangaModel = rememberScreenModel { MigrateSourceScreenModel() }
+    val mangaState by mangaModel.state.collectAsState()
+    val novelModel = rememberScreenModel { MigrateNovelSourcesScreenModel() }
+    val novelState by novelModel.state.collectAsState()
+    val contentType by browseScreenModel.contentType.collectAsState()
+
+    return TabContent(
+        titleRes = MR.strings.label_migration,
+        actions = listOf(
+            AppBar.Action(
+                title = stringResource(MR.strings.migration_help_guide),
+                icon = Icons.AutoMirrored.Outlined.HelpOutline,
+                onClick = { uriHandler.openUri("https://mihon.app/docs/guides/source-migration") },
+            ),
+        ),
+        content = { contentPadding, _ ->
+            Column {
+                ContentTypeFilterChips(
+                    selected = contentType,
+                    onSelect = browseScreenModel::setContentType,
+                )
+                when (contentType) {
+                    ContentType.MANGA -> MigrateSourceScreen(
+                        state = mangaState,
+                        contentPadding = contentPadding,
+                        onClickItem = { navigator.push(MigrateMangaScreen(it.id)) },
+                        onToggleSortingDirection = mangaModel::toggleSortingDirection,
+                        onToggleSortingMode = mangaModel::toggleSortingMode,
+                    )
+                    ContentType.NOVELS -> NovelMigrateSourceList(
+                        state = novelState,
+                        contentPadding = contentPadding,
+                        onClickItem = { navigator.push(MigrateNovelScreen(it.id)) },
+                        onToggleSortingMode = novelModel::toggleSortingMode,
+                        onToggleSortingDirection = novelModel::toggleSortingDirection,
+                    )
+                    ContentType.ALL -> CombinedMigrateSourcesContent(
+                        mangaState = mangaState,
+                        novelState = novelState,
+                        contentPadding = contentPadding,
+                        onClickMangaItem = { navigator.push(MigrateMangaScreen(it.id)) },
+                        onClickNovelItem = { navigator.push(MigrateNovelScreen(it.id)) },
+                    )
+                }
+            }
+        },
+    )
+}
+
+@Composable
+private fun NovelMigrateSourceList(
+    state: MigrateNovelSourcesScreenModel.State,
+    contentPadding: PaddingValues,
+    onClickItem: (NovelMigrateSource) -> Unit,
+    onToggleSortingMode: () -> Unit,
+    onToggleSortingDirection: () -> Unit,
+) {
+    when {
+        state.isLoading -> LoadingScreen(Modifier.padding(contentPadding))
+        state.isEmpty -> EmptyScreen(
+            stringRes = MR.strings.information_empty_library,
+            modifier = Modifier.padding(contentPadding),
+        )
+        else -> ScrollbarLazyColumn(contentPadding = contentPadding + topSmallPaddingValues) {
+            stickyHeader(key = STICKY_HEADER_KEY_PREFIX) {
+                MigrateSortHeader(
+                    sortingMode = state.sortingMode,
+                    sortingDirection = state.sortingDirection,
+                    onToggleSortingMode = onToggleSortingMode,
+                    onToggleSortingDirection = onToggleSortingDirection,
+                )
+            }
+            novelMigrateSourceItems(state.items, onClickItem)
+        }
+    }
+}
+
+/**
+ * The unified "All" migration list: manga migrate-sources under a Manga header, then novel
+ * migrate-sources under a Novels header. No sort toggle here (matching the Sources-tab All view);
+ * each single-type chip carries its own sort header.
+ */
+@Composable
+private fun CombinedMigrateSourcesContent(
+    mangaState: MigrateSourceScreenModel.State,
+    novelState: MigrateNovelSourcesScreenModel.State,
+    contentPadding: PaddingValues,
+    onClickMangaItem: (Source) -> Unit,
+    onClickNovelItem: (NovelMigrateSource) -> Unit,
+) {
+    ScrollbarLazyColumn(contentPadding = contentPadding + topSmallPaddingValues) {
+        if (mangaState.items.isNotEmpty()) {
+            item(key = "all-migrate-manga-header") {
+                BrowseSectionHeader(title = stringResource(MR.strings.content_type_manga))
+            }
+            items(
+                items = mangaState.items,
+                key = { (source, _) -> "migrate-manga-${source.id}" },
+            ) { (source, count) ->
+                MangaMigrateSourceRow(source = source, count = count, onClick = { onClickMangaItem(source) })
+            }
+        }
+        if (novelState.items.isNotEmpty()) {
+            item(key = "all-migrate-novels-header") {
+                BrowseSectionHeader(title = stringResource(MR.strings.content_type_novels))
+            }
+            novelMigrateSourceItems(novelState.items, onClickNovelItem)
+        }
+    }
+}
+
+private fun LazyListScope.novelMigrateSourceItems(
+    items: List<NovelMigrateSource>,
+    onClickItem: (NovelMigrateSource) -> Unit,
+) {
+    items(items = items, key = { "migrate-novel-${it.id}" }) { item ->
+        NovelSourceRow(
+            name = item.name,
+            lang = item.lang,
+            iconUrl = item.iconUrl,
+            onClickItem = { onClickItem(item) },
+            action = { BadgeGroup { Badge(text = "${item.count}") } },
+        )
+    }
+}
+
+@Composable
+private fun MangaMigrateSourceRow(source: Source, count: Long, onClick: () -> Unit) {
+    BaseSourceItem(
+        source = source,
+        showLanguageInContent = source.lang != "",
+        onClickItem = onClick,
+        action = { BadgeGroup { Badge(text = "$count") } },
+    )
+}
+
+/** The "Select a source to migrate from" prompt plus the alpha/total and asc/desc sort toggles,
+ *  mirroring Mihon's manga [MigrateSourceScreen] header so the Novels list sorts identically. */
+@Composable
+private fun MigrateSortHeader(
+    sortingMode: SetMigrateSorting.Mode,
+    sortingDirection: SetMigrateSorting.Direction,
+    onToggleSortingMode: () -> Unit,
+    onToggleSortingDirection: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .background(MaterialTheme.colorScheme.background)
+            .padding(start = MaterialTheme.padding.medium),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = stringResource(MR.strings.migration_selection_prompt),
+            modifier = Modifier.weight(1f),
+            style = MaterialTheme.typography.header,
+        )
+        IconButton(onClick = onToggleSortingMode) {
+            when (sortingMode) {
+                SetMigrateSorting.Mode.ALPHABETICAL -> Icon(
+                    Icons.Outlined.SortByAlpha,
+                    contentDescription = stringResource(MR.strings.action_sort_alpha),
+                )
+                SetMigrateSorting.Mode.TOTAL -> Icon(
+                    Icons.Outlined.Numbers,
+                    contentDescription = stringResource(MR.strings.action_sort_count),
+                )
+            }
+        }
+        IconButton(onClick = onToggleSortingDirection) {
+            when (sortingDirection) {
+                SetMigrateSorting.Direction.ASCENDING -> Icon(
+                    Icons.Outlined.ArrowUpward,
+                    contentDescription = stringResource(MR.strings.action_asc),
+                )
+                SetMigrateSorting.Direction.DESCENDING -> Icon(
+                    Icons.Outlined.ArrowDownward,
+                    contentDescription = stringResource(MR.strings.action_desc),
+                )
+            }
+        }
+    }
+}

--- a/app/src/test/java/reikai/presentation/browse/migrate/MigrateNovelSourcesTest.kt
+++ b/app/src/test/java/reikai/presentation/browse/migrate/MigrateNovelSourcesTest.kt
@@ -1,0 +1,88 @@
+package reikai.presentation.browse.migrate
+
+import eu.kanade.domain.source.interactor.SetMigrateSorting
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import reikai.domain.novel.LnSourceIdentity
+
+class MigrateNovelSourcesTest {
+
+    private fun id(name: String) = LnSourceIdentity(name = name)
+
+    @Test
+    fun `counts favorited novels per source`() {
+        val rows = buildNovelMigrateSources(
+            sourceIdsPerNovel = listOf("a", "a", "b"),
+            installed = mapOf("a" to id("Alpha"), "b" to id("Bravo")),
+            cached = emptyMap(),
+        )
+        rows.associate { it.id to it.count } shouldBe mapOf("a" to 2, "b" to 1)
+    }
+
+    @Test
+    fun `resolves name and icon from the installed source`() {
+        val rows = buildNovelMigrateSources(
+            sourceIdsPerNovel = listOf("a"),
+            installed = mapOf("a" to LnSourceIdentity(name = "Alpha", iconUrl = "http://i/a.png")),
+            cached = mapOf("a" to id("Stale")),
+        )
+        rows.single().let { it.name to it.iconUrl } shouldBe ("Alpha" to "http://i/a.png")
+    }
+
+    @Test
+    fun `falls back to the last-known cache when the plugin is uninstalled`() {
+        val rows = buildNovelMigrateSources(
+            sourceIdsPerNovel = listOf("a"),
+            installed = emptyMap(),
+            cached = mapOf("a" to LnSourceIdentity(name = "Alpha", iconUrl = "http://i/a.png")),
+        )
+        rows.single().let { Triple(it.name, it.iconUrl, it.isInstalled) } shouldBe
+            Triple("Alpha", "http://i/a.png", false)
+    }
+
+    @Test
+    fun `falls back to the raw plugin id when never seen`() {
+        val rows = buildNovelMigrateSources(
+            sourceIdsPerNovel = listOf("novelbin"),
+            installed = emptyMap(),
+            cached = emptyMap(),
+        )
+        rows.single().let { Triple(it.name, it.iconUrl, it.isInstalled) } shouldBe
+            Triple("novelbin", null, false)
+    }
+
+    @Test
+    fun `marks installed only when the source is currently registered`() {
+        val rows = buildNovelMigrateSources(
+            sourceIdsPerNovel = listOf("a", "b"),
+            installed = mapOf("a" to id("Alpha")),
+            cached = mapOf("b" to id("Bravo")),
+        )
+        rows.associate { it.id to it.isInstalled } shouldBe mapOf("a" to true, "b" to false)
+    }
+
+    @Test
+    fun `sorts alphabetically ascending by name`() {
+        val rows = listOf(row("c", "Charlie", 1), row("a", "alpha", 5), row("b", "Bravo", 3))
+        val sorted = sortNovelMigrateSources(
+            rows,
+            SetMigrateSorting.Mode.ALPHABETICAL,
+            SetMigrateSorting.Direction.ASCENDING,
+        )
+        sorted.map { it.id } shouldBe listOf("a", "b", "c")
+    }
+
+    @Test
+    fun `sorts by total count descending`() {
+        val rows = listOf(row("c", "Charlie", 1), row("a", "Alpha", 5), row("b", "Bravo", 3))
+        val sorted = sortNovelMigrateSources(
+            rows,
+            SetMigrateSorting.Mode.TOTAL,
+            SetMigrateSorting.Direction.DESCENDING,
+        )
+        sorted.map { it.id } shouldBe listOf("a", "b", "c")
+    }
+
+    private fun row(id: String, name: String, count: Int) =
+        NovelMigrateSource(id = id, name = name, iconUrl = null, lang = "", count = count, isInstalled = true)
+}


### PR DESCRIPTION
Adds a Novels mode to **Browse → Migration**, behind the same All / Manga / Novels chip as the rest of Browse, so saved light novels can be migrated the same way as manga.

## What changed
- Pick a novel source to see its saved novels, select the ones to move, and run them through the existing novel migration flow.
- A source still appears (with its last-known name and icon) even after its plugin is uninstalled, so you can always migrate away from it.
- The per-source flow is source-scoped: it goes straight to the migrate config and skips the merge-group picker. That pre-step stays on the library and details routes, where the selection isn't per-source.

## Under the hood
- A chip-gated wrapper tab replaces Mihon's `migrateSourceTab` via a `// RK` island; Manga reuses `MigrateSourceScreen` verbatim, and All interleaves both source types under headers.
- Favorited novels are grouped by source in memory (no schema change); a source's name/icon resolves installed, then last-known cache, then the raw plugin id.
- The cache (`seenNovelSources`) is written on every source load and kept across uninstall, the novel parallel of manga's stub-source names.

Verified: unit tests (source grouping, the installed/cache/raw resolution, sort), `compileDebugKotlin`, a minified R8 `assemblePreview`, and on-device (per-source flow, a merged entry, the uninstalled-source stub, and the library migrate route unchanged).
