### PR TITLE
docs: retire stale design/mihon-rebase branch references

### DIFF
--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -55,16 +55,6 @@ When the user asks to cut a release:
 1. Rename `## [Unreleased]` to the version.
 2. Add a new empty `## [Unreleased]` section above it for the next cycle.
 
-### Yōkai -> Reikai debrand (do at the release-cut)
-
-The fork was "Yōkai-Y2K" on the old Yōkai base; the Mihon-based release ships as **Reikai**. Sweep every lingering reference (`git grep -iE 'yōkai|yokai|y2k|null2264'`, ignoring `refs/`) and sort each into one of three buckets:
-
-- **Keep, load-bearing identity (NEVER touch):** the `.y2k` / `.debugY2k` `applicationId` suffix in `app/build.gradle.kts` (it is what upgrades existing installs in place), and the `yokai` / `y2k` / `ln_*` **preference key strings** (renaming them orphans user data; the comments beside them say why they are preserved).
-- **Keep as the historical record:** the old `Yōkai-Y2K v1.9.7.5.x` **releases on `unseensnick/Reikai`**, the CHANGELOG's `1.9.7.5.x` entries + its "earlier versions tracked Yōkai" header note, and the rebase/migration docs (`docs/dev/plans/rebase-overview.md`, `docs/backup-restore.md`). These are the record of where Reikai came from.
-- **Update / debrand:** user-facing + brand docs (`README.md`, `PRODUCT.md`, `DESIGN.md`), `docs/dev/development.md` (still describes the Yōkai base), and the icon art (`art/icon/*.svg`, any launcher webp carrying "Yōkai-Y2K" text). Reframe "Yōkai-era" code comments only when already editing that file (low priority, they are accurate history).
-
-**The old releases specifically:** do NOT delete the `v1.9.7.5.x` stable releases. They are the only migration path for existing `.yokai` users (back up -> install the new `.y2k` build -> restore, per `docs/backup-restore.md`). Edit the latest one's notes to point at that migration and the new Reikai release. The old `r6xxx` "Yōkai-Y2K Nightly" pre-releases were already removed (the nightly channel is now `unseensnick/Reikai-preview`); new stable releases are named `Reikai vX`.
-
 ## Commits & PRs
 
 After code changes, create a git commit (do not push unless asked).

--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -136,7 +136,7 @@ A small commit needs no headers, just the subject plus a sentence or two (see th
 
 **Conventional types:** `feat:` new feature, `fix:` bug fix, `docs:` documentation only, `chore:` build / tooling, `refactor:` / `test:` / `perf:` as named.
 
-During the Mihon rebase, all work lands on the **`design/mihon-rebase`** branch (it becomes the new `main` when the rebase ships). PRs target `design/mihon-rebase`, not `main`. Patches to Mihon's own files are fenced with `// RK -->` / `// RK <--`.
+Work lands on `main` (the Mihon-based main). PRs target `main`. Patches to Mihon's own files are fenced with `// RK -->` / `// RK <--`.
 
 For day-to-day commit / push / PR work, run **`/ship`** (or **`/debug-fix --fast`** for hotfixes). Those bake in the conventions: no `Co-Authored-By` lines in commits, no `## Test plan` section or `🤖 Generated with [Claude Code]` footer in PR bodies, and `--repo unseensnick/Reikai` (the repo otherwise targets the wrong remote).
 
@@ -149,7 +149,7 @@ Don't bump per-push; ship alpha cycles by branch/tag. At release-cut, bump both 
 
 ## Syncing with Mihon (the live base)
 
-Mihon upstream changes are **ported manually** from the local `refs/mihon/` clone. Never `git merge` Mihon into `design/mihon-rebase` (it would clobber Reikai patches and identity). When porting an upstream change that touches a file Reikai has patched, re-apply inside the `// RK` island.
+Mihon upstream changes are **ported manually** from the local `refs/mihon/` clone. Never `git merge` Mihon into `main` (it would clobber Reikai patches and identity). When porting an upstream change that touches a file Reikai has patched, re-apply inside the `// RK` island.
 
 **Commit-message reference convention (required):** in a Mihon-sync commit, reference an upstream pull request or issue as **`mihonapp/mihon#<num>`** (GitHub renders this as a link to the Mihon repo). Never a bare `#<num>` (it auto-links to a *Reikai* issue/PR) nor a bare `<num>`. Also cite the upstream short-SHA (e.g. `mihon 80541831b`). The full commit-message template, the porting method (verbatim copy for marker-free files, hand-merge inside `// RK` islands for patched ones), and the running synced-base ledger live in the **`upstream-sync` memory**.
 

--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -55,17 +55,6 @@ When the user asks to cut a release:
 1. Rename `## [Unreleased]` to the version.
 2. Add a new empty `## [Unreleased]` section above it for the next cycle.
 
-### Deferred history cleanup (do at the release-cut that ships `design/mihon-rebase` as `main`)
-
-The goal: **the whole `design/mihon-rebase` history reads in the commit message standard below before it becomes `main`.** Many commits already on the branch predate the standard, and the Mihon-sync ones use broken reference forms (`Mihon PR #<digit>`, bare `#<digit>`) that GitHub auto-links to the wrong (Reikai) repo. They are pushed, so this is a history rewrite + force-push, only worth doing at the natural rewrite point: the cut that turns this branch into `main` (it replaces the old Yōkai-based `main`, so this is cleaning the branch's own history, not a squash-merge). The branch is single-owner, so the force-push is acceptable with the user's explicit OK.
-
-**Recommended method (condense to one clean commit per feature, not a single squash):**
-
-1. **Tag a backup** first (e.g. `pre-cleanup-<date>`).
-2. **Scripted reference fix across all commits** (`git filter-repo --message-callback`, or `git filter-branch --msg-filter`): `Mihon PR #<n>` / `Mihon Issue #<n>` / a bare upstream `#<n>` -> `mihonapp/mihon#<n>`; ROADMAP `(#8)` -> `Roadmap N`.
-3. **`git rebase -i`** to bring **every** commit to the standard: `fixup` the incremental WIP and the `docs: mark #X done` churn into their feature commit so each meaningful feature is one commit, then `reword` every surviving commit to comply, leaving none in the old style. Non-trivial commits get the lead + bullets body; for a trivial commit a clean conventional subject is itself full compliance (the standard omits the body there). Result: a fully standard-compliant, ~one-commit-per-feature history (navigable + bisectable), not one giant squash (which loses bisect).
-4. **Update the `upstream-sync` memory's ledger SHAs** afterward (the rewrite changes every SHA from the edit point forward), then `--force-with-lease` and point `main` at it.
-
 ### Yōkai -> Reikai debrand (do at the release-cut)
 
 The fork was "Yōkai-Y2K" on the old Yōkai base; the Mihon-based release ships as **Reikai**. Sweep every lingering reference (`git grep -iE 'yōkai|yokai|y2k|null2264'`, ignoring `refs/`) and sort each into one of three buckets:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Android manga + light-novel reader. Personal fork built on [Mihon](https://github.com/mihonapp/mihon) (Tachiyomi lineage), adding light novels, multi-source grouping, manual merge/unmerge, and category sort order.
 
-**Rebase onto Mihon (started 2026-06, functionally complete):** Reikai was previously a fork of [Yōkai](https://github.com/null2264/yokai); it has been rebased onto Mihon, with the core sequence and most of the manga-vs-novel parity backlog shipped (final low-value parity item + release cut remain). The Mihon-based foundation lives on the `design/mihon-rebase` branch (it becomes `main` at the release cut). The old Yōkai-based code (branch `design/library-compose`) is kept only as the porting reference. Full plan and feature list: [ROADMAP.md](ROADMAP.md) plus the per-feature records in [docs/dev/plans/](docs/dev/plans/); ongoing status: the `mihon-rebase` memory.
+**Rebase onto Mihon (shipped 2026-06 as v0.1.0):** Reikai was previously a fork of [Yōkai](https://github.com/null2264/yokai); it has been rebased onto Mihon. The rebase has shipped: `main` is now the Mihon-based main (the old `design/mihon-rebase` branch is gone). The old Yōkai-based code (branch `design/library-compose`) is kept only as the porting reference. Full plan and feature list: [ROADMAP.md](ROADMAP.md) plus the per-feature records in [docs/dev/plans/](docs/dev/plans/); ongoing status: the `mihon-rebase` memory.
 
 ## Working approach
 
@@ -98,6 +98,6 @@ Build in Android Studio. Gradle: JDK 21 (Temurin 21.0.11; matches `.github/.java
 - `/scout` — investigate a non-trivial task before planning; produces a findings report grounded in `file:line` citations. Use before ports or cross-cutting changes.
 - `/tighten` — trim verbose prose, walls of text, journey narration, and WHAT comments from docs (and, on ask, code comments) without losing vital info. Always plans before editing.
 - `/port-audit` — audit a port for behavioral parity against the Reikai source on `design/library-compose`. Use after a phase ships.
-- `/ship` — scan, stage, commit, push, PR with Reikai conventions (no `Co-Authored-By`, no `## Test plan`; `--repo unseensnick/Reikai`). During the rebase, work targets `design/mihon-rebase`, not `main`.
+- `/ship` — scan, stage, commit, push, PR with Reikai conventions (no `Co-Authored-By`, no `## Test plan`; `--repo unseensnick/Reikai`). Work targets `main`.
 - `/debug-fix` — bug-hunt workflow (`--fast` for hotfixes).
 - `/pr-review`, `/refactor`, `/test-writer`, `/tdd`, `/explain`, `/context-budget`.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Reikai Roadmap
 
-Forward-looking plan for the Mihon rebase (branch `design/mihon-rebase`, which becomes `main` when the rebase ships). This is the single backlog: what is left, in what order, and what already landed.
+Forward-looking plan for Reikai on the Mihon base (the rebase has shipped; `main` is the Mihon-based main). This is the single backlog: what is left, in what order, and what already landed.
 
 Per-feature implementation and decision records live in [docs/dev/plans/](docs/dev/plans/). The format this file follows is defined in [.claude/rules/workflow.md](.claude/rules/workflow.md) ("Roadmap & plans"). Day-to-day session state lives in `Handoff.md` (gitignored).
 
@@ -28,9 +28,7 @@ Nothing actively in progress.
 
 ## Next
 
-Queued, roughly in priority order.
-
-- **Publish a fresh preview + release-pipeline first-run verify**  `[S]`: the preview prune bug is now FIXED (`e1960e06e`, prune by build number not date), so kick a manual build, `gh workflow run preview.yml --ref design/mihon-rebase --repo unseensnick/Reikai`, and confirm r352 lands on `unseensnick/Reikai-preview` and sticks (the prune no longer eats the newest). Then the broader verify: a tag draft-publishes a release and the in-app updater prompts on both. The `PREVIEW_REPO_TOKEN` PAT already works; builds publish; this is now just the manual trigger + check.
+Nothing queued.
 
 ## Later
 
@@ -151,7 +149,7 @@ Terse done-log, grouped by area. Full detail in the linked plan docs.
 - Round 2 parity sweep: novel default-category for new novels (`db116e592`), add-to-library button on novel history rows (`658be0feb`), novel source enable/disable (`bf538dabf`), novel chapter "downloaded" filter (`143abf9cf`), and novel update-error tracking + per-category manual update (shared All / Manga / Novels Update-errors screen, fixes the Novels-chip refresh that fired the manga job) (`f28259d00`).
 
 ### Adult / EXH subsystem (phases 1-4 + 5a + 5b)
-Ported from `refs/komikku`, re-typed onto Mihon's models. Committed on `design/mihon-rebase`, not yet pushed; on-device verified on emulator-5554.
+Ported from `refs/komikku`, re-typed onto Mihon's models. On `main`; on-device verified on emulator-5554.
 - Phase 1: delegation core (`EnhancedHttpSource` / `DelegatedHttpSource`) + gallery-metadata store (`search_metadata` / `search_tags` / `search_titles`, migration 23) + the 4 free enhanced sources (nHentai, Pururin, 8Muses, LANraragi) + URL import (`08d9f2bfa`, `24a51cb03`, `87abe5245`).
 - Phase 2: built-in E-Hentai / ExHentai source (anonymous browse + read, full gallery filters, gallery-version chapters); Settings → Advanced "Enable adult sources" toggle; ExHentai WebView login; E-Hentai settings screen + server-profile sync (uconfig) (`41e85aac8`, `fc73b2adc`, `29d05b931`, `497b8d9f1`, `1f9ec4cab`, `692c98200`).
 - Phase 3: E-Hentai tag autocomplete (full EHTags catalogue), library search by gallery tags, Compose-native gallery metadata viewer (`2e3a1a892`, `15a3a4832`, `b6655ae08`).
@@ -169,4 +167,4 @@ Ported from `refs/komikku`, re-typed onto Mihon's models. Committed on `design/m
 
 ## Conventions
 
-Branch `design/mihon-rebase`; edits to Mihon files fenced with `// RK -->` / `// RK <--`; net-new code in `reikai.*`; Injekt DI (no Koin); immutable `tachiyomi.domain` models; SQLDelight migrations are additive. Upstream Mihon changes are ported by hand from `refs/mihon/` (never `git merge`). Full detail in [CLAUDE.md](CLAUDE.md), [.claude/rules/](.claude/rules/), the [plan docs](docs/dev/plans/), and the memories.
+Branch `main`; edits to Mihon files fenced with `// RK -->` / `// RK <--`; net-new code in `reikai.*`; Injekt DI (no Koin); immutable `tachiyomi.domain` models; SQLDelight migrations are additive. Upstream Mihon changes are ported by hand from `refs/mihon/` (never `git merge`). Full detail in [CLAUDE.md](CLAUDE.md), [.claude/rules/](.claude/rules/), the [plan docs](docs/dev/plans/), and the memories.

--- a/docs/dev/development.md
+++ b/docs/dev/development.md
@@ -12,7 +12,7 @@
 
 ## Rebase status
 
-The rebase runs in phases (P0-P9). The master plan and per-phase status live in [ROADMAP.md](../../ROADMAP.md), the per-feature implementation records in [plans/](plans/), and the `mihon-rebase` memory. The old Yōkai-based code stays on the `design/library-compose` branch as the porting reference. The Mihon-based work lands on `design/mihon-rebase`.
+The rebase has shipped: `main` is the Mihon-based main. The master plan and per-phase record live in [ROADMAP.md](../../ROADMAP.md), the per-feature implementation records in [plans/](plans/), and the `mihon-rebase` memory. The old Yōkai-based code stays on the `design/library-compose` branch as the porting reference.
 
 ## Canonical rules
 

--- a/docs/dev/ln-plugin-host.md
+++ b/docs/dev/ln-plugin-host.md
@@ -11,8 +11,7 @@ the layout.
 
 ## Where things stand
 
-The LN host ships on the `design/mihon-rebase` branch (the branch that becomes `main` when the rebase
-lands). The vertical is complete and on-device verified: installing lnreader plugins from a repo,
+The LN host ships on `main` (the Mihon-based main). The vertical is complete and on-device verified: installing lnreader plugins from a repo,
 browsing/searching a source, saving novels to the library, reading chapters, downloading, multi-source
 merge, tracking, and backup are all wired. The host runs lnreader plugins unmodified in a headless
 QuickJS engine: no WebView and no Activity, so a source works the same on a screen or in a background

--- a/docs/dev/plans/exh-subsystem.md
+++ b/docs/dev/plans/exh-subsystem.md
@@ -43,7 +43,7 @@ These are the Mihon-file edits that wire the subsystem in (grep `// RK`):
 
 ## Status
 
-Shipped on `design/mihon-rebase`, on-device verified on emulator-5554 (account push/remove and deep version-reconciliation are faithful ports verified by compile + non-account paths; live triggering needs an ExHentai login, user-side). Phase commits:
+Shipped on `main`, on-device verified on emulator-5554 (account push/remove and deep version-reconciliation are faithful ports verified by compile + non-account paths; live triggering needs an ExHentai login, user-side). Phase commits:
 
 - Phase 1 (delegation core + metadata store + 4 free enhanced sources + URL import): `08d9f2bfa`, `24a51cb03`, `87abe5245`.
 - Phase 2 (built-in EH/ExHentai, adult-sources toggle, ExHentai login, settings + uconfig): `41e85aac8`, `fc73b2adc`, `29d05b931`, `497b8d9f1`, `1f9ec4cab`, `692c98200`.

--- a/docs/dev/plans/manga-details-parity.md
+++ b/docs/dev/plans/manga-details-parity.md
@@ -12,7 +12,7 @@ The rebase swapped Reikai's Yōkai-era details screen (a View-based Conductor co
 
 ## Approach
 
-What landed and the mechanism behind each piece. This describes CURRENT behavior on `design/mihon-rebase`.
+What landed and the mechanism behind each piece. This describes CURRENT behavior on `main`.
 
 **Cover-accent backdrop.** Opening a manga tints the whole details screen with a color pulled from its cover art: a red cover gives a warm header, a blue cover a cool one. In Mihon this color is the `seedColor` field on the screen state, extracted from the cover bitmap (`MangaScreenModel.kt`, set inside `updateSeedColor`). Reikai's contribution is applying it as the live theme: a `// RK` block wraps the whole screen in `TachiyomiTheme(seedColor = ...)`, gated on a `themeCoverBased` preference so a user can turn it off (`MangaScreen.kt`). The blurred-cover backdrop and its vertical gradient live in the info header (`MangaInfoHeader.kt`).
 
@@ -48,7 +48,7 @@ Mihon presentation composables (native, confirmed present, no Reikai edits neede
 
 ## Status
 
-Shipped. P3 is done (Roadmap P3, status done): merge / Manage-sources UI, private tracking, two-finger range select, cover-accent backdrop, and the recommendations carousel are all on `design/mihon-rebase` and on-device verified.
+Shipped. P3 is done (Roadmap P3, status done): merge / Manage-sources UI, private tracking, two-finger range select, cover-accent backdrop, and the recommendations carousel are all on `main` and on-device verified.
 
 ## Decisions & tradeoffs
 

--- a/docs/dev/plans/manga-merge-engine.md
+++ b/docs/dev/plans/manga-merge-engine.md
@@ -75,7 +75,7 @@ Tracker links mirror across the group via [`PropagateTrackerLinks`](../../../app
 
 ## Key files
 
-Confirmed present on `design/mihon-rebase`:
+Confirmed present on `main`:
 
 - [`app/src/main/java/reikai/domain/MergeGroupAlgebra.kt`](../../../app/src/main/java/reikai/domain/MergeGroupAlgebra.kt): the pure group set-algebra + collapse parsers, shared with novels.
 - [`app/src/main/java/reikai/domain/manga/MangaMergeManager.kt`](../../../app/src/main/java/reikai/domain/manga/MangaMergeManager.kt): manga merge/split/dissolve operations, same-title resolution, tracker healing.

--- a/docs/dev/plans/novel-merge.md
+++ b/docs/dev/plans/novel-merge.md
@@ -69,7 +69,7 @@ The split-vs-dissolve decision is merge-engine semantics, so it lives in the man
 
 ## Key files
 
-Confirmed present on `design/mihon-rebase`:
+Confirmed present on `main`:
 
 - [`app/src/main/java/reikai/domain/MergeGroupAlgebra.kt`](../../../app/src/main/java/reikai/domain/MergeGroupAlgebra.kt): the pure group set-algebra + collapse parsers, shared with manga.
 - [`app/src/main/java/reikai/domain/novel/NovelMergeManager.kt`](../../../app/src/main/java/reikai/domain/novel/NovelMergeManager.kt): novel merge/split/dissolve, same-title resolution, the author guard, `splitOrDissolve`, `relatedNovelIdsFor`, and `seriesGroupKeys` for the Updates group-by-series.

--- a/docs/dev/plans/unified-updates.md
+++ b/docs/dev/plans/unified-updates.md
@@ -63,7 +63,7 @@ Key files (app module): `reikai/presentation/widget/UnifiedUpdatesGlanceWidget.k
 
 ## Status
 
-Shipped and on-device verified (Z Fold / Fold6): all four pieces of the in-app feed (consolidation, novel filters, by-category, group-by-series) are live on `design/mihon-rebase`, plus the home-screen widget (`b2e4d1cb8`). The novel History tab is the History-side twin of this same consolidation pattern; see novel-parity-backlog.md.
+Shipped and on-device verified (Z Fold / Fold6): all four pieces of the in-app feed (consolidation, novel filters, by-category, group-by-series) are live on `main`, plus the home-screen widget (`b2e4d1cb8`). The novel History tab is the History-side twin of this same consolidation pattern; see novel-parity-backlog.md.
 
 ## Decisions & tradeoffs
 


### PR DESCRIPTION
Cleans up docs that still referred to the retired `design/mihon-rebase` branch. The Mihon rebase has shipped (v0.1.0) and `main` is now the Mihon-based main, so the old branch references were stale and misleading.

## What changed
- `CLAUDE.md`, `.claude/rules/workflow.md`, `ROADMAP.md`, `docs/dev/development.md`, `ln-plugin-host.md`, and five `docs/dev/plans/*.md` now say `main` for where work lands, what PRs target, and where shipped features live. Location lines were renamed; the "during the rebase / becomes main" framing was reworded to "the rebase has shipped."
- Removed the completed **"Publish a fresh preview"** roadmap item; `## Next` now reads "Nothing queued."
- Removed the two completed one-time release-cut sections from the workflow rules (**"Deferred history cleanup"** and **"Yōkai → Reikai debrand"**), which both ran at the cut. `## Cutting a release` now keeps just the generic per-release steps.

The only remaining mention of the old branch name is one deliberate line in `CLAUDE.md` noting it is gone.
