### PR TITLE
fix: recover library when updating from old Yōkai-Y2K (0.1.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,15 @@ Reikai uses its own [Semantic Versioning](https://semver.org/) from the Mihon-ba
 
 ## [Unreleased]
 
+## [0.1.2]
+
 ### Additions
 
 - **Migrate light novels from Browse → Migration.** The Migration tab now has the same All / Manga / Novels switch as the rest of Browse: pick a novel source to see its saved novels, select the ones to move, and run them through the existing novel migration flow. A source still shows (with its last-known name and icon) even after its plugin is uninstalled, so you can always migrate away from it.
+
+### Fixes
+
+- **Fixed the crash on launch after updating from an old Yōkai-Y2K build.** Updating in place from a pre-rebase (1.9.x) build left a database the new app couldn't open, so it crashed on startup. It now recovers your manga and novel libraries plus your extension repositories automatically on first launch (a brief notice shows while it restores), with your previous data kept safe. Merged series come back unmerged, so re-create any merges you want. ([#11](https://github.com/unseensnick/Reikai/issues/11))
 
 ## [0.1.1]
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -39,8 +39,8 @@ android {
         // versionCode must keep climbing and stay above the last Yokai-based build (168) so installs upgrade in place.
         applicationId = "eu.kanade.tachiyomi"
 
-        versionCode = 171
-        versionName = "0.1.1"
+        versionCode = 172
+        versionName = "0.1.2"
         // RK <--
 
         buildConfigField("String", "COMMIT_COUNT", "\"${getLatestCommitCount()}\"")

--- a/app/src/main/java/eu/kanade/tachiyomi/App.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/App.kt
@@ -7,9 +7,11 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.net.Uri
 import android.os.Build
 import android.os.Looper
 import android.webkit.WebView
+import android.widget.Toast
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
@@ -30,6 +32,8 @@ import eu.kanade.domain.ui.model.setAppCompatDelegateThemeMode
 import eu.kanade.tachiyomi.core.security.PrivacyPreferences
 import eu.kanade.tachiyomi.crash.CrashActivity
 import eu.kanade.tachiyomi.crash.GlobalExceptionHandler
+import eu.kanade.tachiyomi.data.backup.restore.BackupRestoreJob
+import eu.kanade.tachiyomi.data.backup.restore.RestoreOptions
 import eu.kanade.tachiyomi.data.coil.BufferedSourceFetcher
 import eu.kanade.tachiyomi.data.coil.MangaCoverFetcher
 import eu.kanade.tachiyomi.data.coil.MangaCoverKeyer
@@ -48,6 +52,7 @@ import eu.kanade.tachiyomi.util.system.WebViewUtil
 import eu.kanade.tachiyomi.util.system.animatorDurationScale
 import eu.kanade.tachiyomi.util.system.cancelNotification
 import eu.kanade.tachiyomi.util.system.notify
+import eu.kanade.tachiyomi.util.system.toast
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -60,6 +65,7 @@ import mihon.telemetry.TelemetryConfig
 import org.conscrypt.Conscrypt
 import reikai.data.coil.NovelCoverFetcher
 import reikai.data.coil.NovelCoverKeyer
+import reikai.data.legacy.LegacyYokaiDbImporter
 import reikai.presentation.widget.UnifiedUpdatesWidgetManager
 import tachiyomi.core.common.i18n.stringResource
 import tachiyomi.core.common.preference.Preference
@@ -103,6 +109,15 @@ class App : Application(), DefaultLifecycleObserver, SingletonImageLoader.Factor
         Injekt.importModule(PreferenceModule(this))
         Injekt.importModule(AppModule(this))
         Injekt.importModule(DomainModule())
+
+        // RK --> recover a library left behind by an in-place update from the old Yōkai-based build.
+        // The old DB shares tachiyomi.db's name but sits at a higher, incompatible schema version, so
+        // SQLDelight skips all migrations and crashes on the first query (no such table). Detect it,
+        // export the library to a backup, and move the old DB aside so a fresh DB is created. Runs
+        // before the DB is first opened (the factories above are lazy); the restore is enqueued at the
+        // end of onCreate once DI is ready. See docs/dev/plans/legacy-yokai-import.md.
+        val legacyImportFile = LegacyYokaiDbImporter.prepareIfLegacyDb(this)
+        // RK <--
 
         setupNotificationChannels()
 
@@ -178,6 +193,23 @@ class App : Application(), DefaultLifecycleObserver, SingletonImageLoader.Factor
         }
 
         initializeMigrator()
+
+        // RK --> restore the recovered legacy library once DI and a fresh DB are ready
+        legacyImportFile?.let { file ->
+            toast(MR.strings.legacy_import_notice, Toast.LENGTH_LONG)
+            BackupRestoreJob.start(
+                context = this,
+                uri = Uri.fromFile(file),
+                options = RestoreOptions(
+                    libraryEntries = true,
+                    categories = true,
+                    appSettings = false,
+                    extensionStores = true,
+                    sourceSettings = false,
+                ),
+            )
+        }
+        // RK <--
     }
 
     private fun initializeMigrator() {

--- a/app/src/main/java/reikai/data/legacy/LegacyYokaiDbImporter.kt
+++ b/app/src/main/java/reikai/data/legacy/LegacyYokaiDbImporter.kt
@@ -1,0 +1,464 @@
+package reikai.data.legacy
+
+import android.content.Context
+import android.database.Cursor
+import android.database.sqlite.SQLiteDatabase
+import android.util.Log
+import eu.kanade.tachiyomi.data.backup.models.Backup
+import eu.kanade.tachiyomi.data.backup.models.BackupCategory
+import eu.kanade.tachiyomi.data.backup.models.BackupChapter
+import eu.kanade.tachiyomi.data.backup.models.BackupExtensionStore
+import eu.kanade.tachiyomi.data.backup.models.BackupHistory
+import eu.kanade.tachiyomi.data.backup.models.BackupManga
+import eu.kanade.tachiyomi.data.backup.models.BackupNovel
+import eu.kanade.tachiyomi.data.backup.models.BackupNovelCategory
+import eu.kanade.tachiyomi.data.backup.models.BackupNovelChapter
+import eu.kanade.tachiyomi.data.backup.models.BackupNovelTracking
+import eu.kanade.tachiyomi.data.backup.models.BackupTracking
+import eu.kanade.tachiyomi.source.model.UpdateStrategy
+import kotlinx.serialization.protobuf.ProtoBuf
+import okio.buffer
+import okio.gzip
+import okio.sink
+import reikai.domain.library.ReikaiLibraryPreferences
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+import java.io.File
+
+/**
+ * Recovers a library left behind when a user updates in place from the old Yōkai-based build.
+ *
+ * Both forks ship the same `tachiyomi.db` filename so installs upgrade in place, but the Yōkai
+ * schema sits at a higher (and otherwise unrelated) version than Mihon's. SQLDelight therefore
+ * treats the on-disk DB as "newer than the code", runs no migrations, and crashes on the first
+ * query against a table Yōkai never had (e.g. `extension_store`). To recover instead of crash, we
+ * read the old library out with plain SQL, write it as a normal backup, and move the old DB aside
+ * so a fresh Mihon DB is created. The restore is enqueued by [eu.kanade.tachiyomi.App] once DI is
+ * ready. Settings and tracker logins are untouched: those live in SharedPreferences, which survive
+ * the in-place update.
+ */
+object LegacyYokaiDbImporter {
+
+    private const val DB_NAME = "tachiyomi.db"
+    private const val IMPORT_BACKUP_NAME = "legacy_yokai_import.tachibk"
+    private const val ASIDE_SUFFIX = ".yokai.bak"
+
+    // android.util.Log, not the logcat extension: this runs before LogcatLogger is installed in
+    // App.onCreate, so the extension would silently drop these lines.
+    private const val TAG = "LegacyYokaiImport"
+
+    /**
+     * If the on-disk database is a legacy Yōkai one, export its library to a backup file and move
+     * the old DB aside so the app can start with a fresh DB. Returns the backup file to restore, or
+     * null when there is nothing to do (no DB, or already a Mihon DB).
+     */
+    fun prepareIfLegacyDb(context: Context): File? {
+        val dbFile = context.getDatabasePath(DB_NAME)
+        if (!dbFile.exists()) return null
+
+        val db = runCatching {
+            SQLiteDatabase.openDatabase(dbFile.path, null, SQLiteDatabase.OPEN_READONLY)
+        }.getOrNull() ?: return null
+
+        if (!db.isLegacyYokaiSchema()) {
+            db.close()
+            return null
+        }
+
+        Log.i(TAG, "Legacy Yokai database detected; recovering library before reset")
+
+        val libraryPreferences = Injekt.get<ReikaiLibraryPreferences>()
+        var backupFile: File? = null
+        try {
+            val backup = db.buildBackup()
+            backupFile = writeBackup(context, backup)
+            Log.i(
+                TAG,
+                "Recovered ${backup.backupManga.size} manga, ${backup.backupNovels.size} novels, " +
+                    "${backup.backupExtensionStores.size} repos",
+            )
+        } catch (e: Throwable) {
+            Log.e(TAG, "Failed to recover legacy Yokai library; resetting DB anyway", e)
+        } finally {
+            db.close()
+            resetMergeState(libraryPreferences)
+            // Always move the old DB aside once detected, so the app starts even if extraction
+            // failed. Renamed, never deleted, so the data stays recoverable.
+            moveAside(dbFile)
+            moveAside(File(dbFile.path + "-wal"))
+            moveAside(File(dbFile.path + "-shm"))
+        }
+        return backupFile
+    }
+
+    /**
+     * Land the migrated library unmerged. A merged group renders under a single representative member, so
+     * after a reset (which reassigns ids, and so which member represents a group) cross-category members
+     * leave categories looking empty. Clearing the stale merge prefs and disabling same-title auto-merge
+     * makes every entry show in all its categories; the user can re-merge in-app. Migration-only: this runs
+     * solely from the legacy-DB path, so a normal restore on a fresh install is unaffected.
+     */
+    private fun resetMergeState(prefs: ReikaiLibraryPreferences) {
+        prefs.mangaManualMerges.set(emptySet())
+        prefs.mangaManualUnmerges.set(emptySet())
+        prefs.novelManualMerges.set(emptySet())
+        prefs.novelManualUnmerges.set(emptySet())
+        prefs.autoMergeSameTitle.set(false)
+        prefs.novelAutoMergeSameTitle.set(false)
+    }
+
+    /** Yōkai's `categories` table carries a `manga_order` column that Mihon's never has. */
+    private fun SQLiteDatabase.isLegacyYokaiSchema(): Boolean =
+        runCatching { hasColumn("categories", "manga_order") }.getOrDefault(false)
+
+    private fun SQLiteDatabase.buildBackup(): Backup {
+        // Manga categories: order value is keyed on for restore, so map id -> sort.
+        val categories = mutableListOf<BackupCategory>()
+        val categorySortById = HashMap<Long, Long>()
+        rawQuery("SELECT _id, name, sort, flags FROM categories WHERE _id > 0", null).use { c ->
+            while (c.moveToNext()) {
+                val sort = c.longOr("sort")
+                categorySortById[c.longOr("_id")] = sort
+                categories += BackupCategory(name = c.strOr("name"), order = sort, flags = c.longOr("flags"))
+            }
+        }
+        val mangaCategoryOrders = groupCategoryOrders("mangas_categories", "manga_id", categorySortById)
+
+        val chaptersByManga = HashMap<Long, MutableList<BackupChapter>>()
+        val chapterUrlById = HashMap<Long, String>()
+        val chapterMangaById = HashMap<Long, Long>()
+        rawQuery(
+            "SELECT _id, manga_id, url, name, scanlator, read, bookmark, last_page_read, " +
+                "chapter_number, source_order, date_fetch, date_upload FROM chapters",
+            null,
+        ).use { c ->
+            while (c.moveToNext()) {
+                val id = c.longOr("_id")
+                val mangaId = c.longOr("manga_id")
+                val url = c.strOr("url")
+                chapterUrlById[id] = url
+                chapterMangaById[id] = mangaId
+                chaptersByManga.getOrPut(mangaId) { mutableListOf() } += BackupChapter(
+                    url = url,
+                    name = c.strOr("name"),
+                    scanlator = c.strOrNull("scanlator"),
+                    read = c.boolOr("read"),
+                    bookmark = c.boolOr("bookmark"),
+                    lastPageRead = c.longOr("last_page_read"),
+                    chapterNumber = c.floatOr("chapter_number"),
+                    sourceOrder = c.longOr("source_order"),
+                    dateFetch = c.longOr("date_fetch"),
+                    dateUpload = c.longOr("date_upload"),
+                )
+            }
+        }
+
+        val historyByManga = HashMap<Long, MutableList<BackupHistory>>()
+        rawQuery("SELECT history_chapter_id, history_last_read, history_time_read FROM history", null).use { c ->
+            while (c.moveToNext()) {
+                val chapterId = c.longOr("history_chapter_id")
+                val url = chapterUrlById[chapterId] ?: continue
+                val mangaId = chapterMangaById[chapterId] ?: continue
+                historyByManga.getOrPut(mangaId) { mutableListOf() } += BackupHistory(
+                    url = url,
+                    lastRead = c.longOr("history_last_read"),
+                    readDuration = c.longOr("history_time_read"),
+                )
+            }
+        }
+
+        val tracksByManga = HashMap<Long, MutableList<BackupTracking>>()
+        rawQuery(
+            "SELECT manga_id, sync_id, remote_id, library_id, title, last_chapter_read, " +
+                "total_chapters, status, score, remote_url, start_date, finish_date FROM manga_sync",
+            null,
+        ).use { c ->
+            while (c.moveToNext()) {
+                tracksByManga.getOrPut(c.longOr("manga_id")) { mutableListOf() } += BackupTracking(
+                    syncId = c.intOr("sync_id"),
+                    libraryId = c.longOr("library_id"),
+                    mediaId = c.longOr("remote_id"),
+                    trackingUrl = c.strOr("remote_url"),
+                    title = c.strOr("title"),
+                    lastChapterRead = c.floatOr("last_chapter_read"),
+                    totalChapters = c.intOr("total_chapters"),
+                    score = c.floatOr("score"),
+                    status = c.intOr("status"),
+                    startedReadingDate = c.longOr("start_date"),
+                    finishedReadingDate = c.longOr("finish_date"),
+                )
+            }
+        }
+
+        val backupManga = mutableListOf<BackupManga>()
+        rawQuery(
+            "SELECT _id, source, url, title, artist, author, description, genre, status, " +
+                "thumbnail_url, viewer, chapter_flags, date_added, update_strategy, initialized " +
+                "FROM mangas WHERE favorite = 1",
+            null,
+        ).use { c ->
+            while (c.moveToNext()) {
+                val id = c.longOr("_id")
+                val source = c.longOr("source")
+                val url = c.strOr("url")
+                backupManga += BackupManga(
+                    source = source,
+                    url = url,
+                    title = c.strOr("title"),
+                    artist = c.strOrNull("artist"),
+                    author = c.strOrNull("author"),
+                    description = c.strOrNull("description"),
+                    genre = splitGenre(c.strOrNull("genre")),
+                    status = c.intOr("status"),
+                    thumbnailUrl = c.strOrNull("thumbnail_url"),
+                    viewer = c.intOr("viewer"),
+                    chapterFlags = c.intOr("chapter_flags"),
+                    dateAdded = c.longOr("date_added"),
+                    updateStrategy = updateStrategyOf(c.longOr("update_strategy")),
+                    initialized = c.boolOr("initialized", default = true),
+                    favorite = true,
+                    chapters = chaptersByManga[id].orEmpty(),
+                    categories = mangaCategoryOrders[id].orEmpty(),
+                    tracking = tracksByManga[id].orEmpty(),
+                    history = historyByManga[id].orEmpty(),
+                )
+            }
+        }
+
+        return Backup(
+            backupManga = backupManga,
+            backupCategories = categories,
+            backupExtensionStores = buildExtensionStores(),
+            backupNovels = buildNovels(),
+            backupNovelCategories = buildNovelCategories(),
+        )
+    }
+
+    /**
+     * Read the old `extension_repos` table (skipped by Mihon's migration 11, so still present) and convert
+     * it to the current repo schema, mirroring that migration: index_url = base_url + "/repo.json", etc.
+     */
+    private fun SQLiteDatabase.buildExtensionStores(): List<BackupExtensionStore> {
+        if (!hasTable("extension_repos")) return emptyList()
+        val stores = mutableListOf<BackupExtensionStore>()
+        rawQuery(
+            "SELECT base_url, name, short_name, website, signing_key_fingerprint FROM extension_repos",
+            null,
+        ).use { c ->
+            while (c.moveToNext()) {
+                val baseUrl = c.strOr("base_url")
+                if (baseUrl.isBlank()) continue
+                val name = c.strOr("name")
+                stores += BackupExtensionStore(
+                    indexUrl = baseUrl.trimEnd('/') + "/repo.json",
+                    name = name,
+                    badgeLabel = c.strOrNull("short_name") ?: name,
+                    signingKey = c.strOr("signing_key_fingerprint"),
+                    contactWebsite = c.strOr("website"),
+                    contactDiscord = null,
+                    isLegacy = true,
+                    extensionListUrl = null,
+                )
+            }
+        }
+        return stores
+    }
+
+    private fun SQLiteDatabase.buildNovelCategories(): List<BackupNovelCategory> {
+        if (!hasTable("novel_categories")) return emptyList()
+        val categories = mutableListOf<BackupNovelCategory>()
+        rawQuery("SELECT _id, name, sort, flags FROM novel_categories WHERE _id > 0", null).use { c ->
+            while (c.moveToNext()) {
+                categories += BackupNovelCategory(
+                    name = c.strOr("name"),
+                    order = c.longOr("sort"),
+                    flags = c.longOr("flags"),
+                )
+            }
+        }
+        return categories
+    }
+
+    private fun SQLiteDatabase.buildNovels(): List<BackupNovel> {
+        if (!hasTable("novels")) return emptyList()
+
+        val categorySortById = HashMap<Long, Long>()
+        rawQuery("SELECT _id, sort FROM novel_categories WHERE _id > 0", null).use { c ->
+            while (c.moveToNext()) categorySortById[c.longOr("_id")] = c.longOr("sort")
+        }
+        val novelCategoryOrders = groupCategoryOrders("novels_categories", "novel_id", categorySortById)
+
+        val chaptersByNovel = HashMap<Long, MutableList<BackupNovelChapter>>()
+        rawQuery(
+            "SELECT novel_id, url, name, read, bookmark, last_text_progress, chapter_number, " +
+                "source_order, date_fetch, date_upload, page FROM novel_chapters",
+            null,
+        ).use { c ->
+            while (c.moveToNext()) {
+                chaptersByNovel.getOrPut(c.longOr("novel_id")) { mutableListOf() } += BackupNovelChapter(
+                    url = c.strOr("url"),
+                    name = c.strOr("name"),
+                    read = c.boolOr("read"),
+                    bookmark = c.boolOr("bookmark"),
+                    lastTextProgress = c.longOr("last_text_progress"),
+                    chapterNumber = c.doubleOr("chapter_number"),
+                    sourceOrder = c.longOr("source_order"),
+                    dateFetch = c.longOr("date_fetch"),
+                    dateUpload = c.longOr("date_upload"),
+                    page = c.strOr("page"),
+                )
+            }
+        }
+
+        val tracksByNovel = HashMap<Long, MutableList<BackupNovelTracking>>()
+        if (hasTable("novel_tracks")) {
+            rawQuery(
+                "SELECT novel_id, sync_id, remote_id, library_id, title, last_chapter_read, " +
+                    "total_chapters, status, score, remote_url, start_date, finish_date FROM novel_tracks",
+                null,
+            ).use { c ->
+                while (c.moveToNext()) {
+                    tracksByNovel.getOrPut(c.longOr("novel_id")) { mutableListOf() } += BackupNovelTracking(
+                        trackerId = c.longOr("sync_id"),
+                        remoteId = c.longOr("remote_id"),
+                        libraryId = c.longOrNull("library_id"),
+                        title = c.strOr("title"),
+                        lastChapterRead = c.doubleOr("last_chapter_read"),
+                        totalChapters = c.longOr("total_chapters"),
+                        status = c.longOr("status"),
+                        score = c.doubleOr("score"),
+                        remoteUrl = c.strOr("remote_url"),
+                        startDate = c.longOr("start_date"),
+                        finishDate = c.longOr("finish_date"),
+                    )
+                }
+            }
+        }
+
+        val novels = mutableListOf<BackupNovel>()
+        rawQuery(
+            "SELECT _id, source, url, title, author, artist, description, genre, status, " +
+                "thumbnail_url, last_update, initialized, chapter_flags, date_added, update_strategy, " +
+                "cover_last_modified, total_pages, last_read_at, edited_flags FROM novels WHERE favorite = 1",
+            null,
+        ).use { c ->
+            while (c.moveToNext()) {
+                val id = c.longOr("_id")
+                novels += BackupNovel(
+                    source = c.strOr("source"),
+                    url = c.strOr("url"),
+                    title = c.strOr("title"),
+                    artist = c.strOrNull("artist"),
+                    author = c.strOrNull("author"),
+                    description = c.strOrNull("description"),
+                    genre = splitGenre(c.strOrNull("genre")),
+                    status = c.longOr("status"),
+                    thumbnailUrl = c.strOrNull("thumbnail_url"),
+                    dateAdded = c.longOr("date_added"),
+                    lastUpdate = c.longOr("last_update"),
+                    initialized = c.boolOr("initialized", default = true),
+                    chapterFlags = c.longOr("chapter_flags"),
+                    updateStrategy = updateStrategyOf(c.longOr("update_strategy")),
+                    coverLastModified = c.longOr("cover_last_modified"),
+                    totalPages = c.longOr("total_pages", default = 1),
+                    lastReadAt = c.longOrNull("last_read_at"),
+                    editedFlags = c.longOr("edited_flags"),
+                    favorite = true,
+                    chapters = chaptersByNovel[id].orEmpty(),
+                    categories = novelCategoryOrders[id].orEmpty(),
+                    tracking = tracksByNovel[id].orEmpty(),
+                )
+            }
+        }
+        return novels
+    }
+
+    private fun SQLiteDatabase.groupCategoryOrders(
+        joinTable: String,
+        idColumn: String,
+        categorySortById: Map<Long, Long>,
+    ): Map<Long, MutableList<Long>> {
+        val result = HashMap<Long, MutableList<Long>>()
+        if (!hasTable(joinTable)) return result
+        rawQuery("SELECT $idColumn, category_id FROM $joinTable", null).use { c ->
+            while (c.moveToNext()) {
+                val order = categorySortById[c.longOr("category_id")] ?: continue
+                result.getOrPut(c.longOr(idColumn)) { mutableListOf() } += order
+            }
+        }
+        return result
+    }
+
+    private fun writeBackup(context: Context, backup: Backup): File {
+        val parser = Injekt.get<ProtoBuf>()
+        val bytes = parser.encodeToByteArray(Backup.serializer(), backup)
+        val file = File(context.cacheDir, IMPORT_BACKUP_NAME)
+        file.sink().gzip().buffer().use { it.write(bytes) }
+        return file
+    }
+
+    private fun moveAside(file: File) {
+        if (!file.exists()) return
+        val aside = File(file.parentFile, file.name + ASIDE_SUFFIX)
+        aside.delete()
+        file.renameTo(aside)
+    }
+
+    private fun splitGenre(raw: String?): List<String> =
+        raw?.split(",")?.mapNotNull { it.trim().ifBlank { null } }.orEmpty()
+
+    private fun updateStrategyOf(value: Long): UpdateStrategy =
+        UpdateStrategy.entries.getOrElse(value.toInt()) { UpdateStrategy.ALWAYS_UPDATE }
+}
+
+private fun SQLiteDatabase.hasTable(table: String): Boolean =
+    rawQuery("SELECT name FROM sqlite_master WHERE type='table' AND name=?", arrayOf(table))
+        .use { it.moveToFirst() }
+
+private fun SQLiteDatabase.hasColumn(table: String, column: String): Boolean =
+    rawQuery("PRAGMA table_info($table)", null).use { c ->
+        val nameIndex = c.getColumnIndex("name")
+        if (nameIndex < 0) return false
+        while (c.moveToNext()) if (c.getString(nameIndex) == column) return true
+        false
+    }
+
+private fun Cursor.strOr(name: String, default: String = ""): String {
+    val i = getColumnIndex(name)
+    return if (i >= 0 && !isNull(i)) getString(i) else default
+}
+
+private fun Cursor.strOrNull(name: String): String? {
+    val i = getColumnIndex(name)
+    return if (i >= 0 && !isNull(i)) getString(i) else null
+}
+
+private fun Cursor.longOr(name: String, default: Long = 0): Long {
+    val i = getColumnIndex(name)
+    return if (i >= 0 && !isNull(i)) getLong(i) else default
+}
+
+private fun Cursor.longOrNull(name: String): Long? {
+    val i = getColumnIndex(name)
+    return if (i >= 0 && !isNull(i)) getLong(i) else null
+}
+
+private fun Cursor.intOr(name: String, default: Int = 0): Int {
+    val i = getColumnIndex(name)
+    return if (i >= 0 && !isNull(i)) getInt(i) else default
+}
+
+private fun Cursor.floatOr(name: String, default: Float = 0f): Float {
+    val i = getColumnIndex(name)
+    return if (i >= 0 && !isNull(i)) getFloat(i) else default
+}
+
+private fun Cursor.doubleOr(name: String, default: Double = 0.0): Double {
+    val i = getColumnIndex(name)
+    return if (i >= 0 && !isNull(i)) getDouble(i) else default
+}
+
+private fun Cursor.boolOr(name: String, default: Boolean = false): Boolean {
+    val i = getColumnIndex(name)
+    return if (i >= 0 && !isNull(i)) getLong(i) != 0L else default
+}

--- a/docs/dev/plans/README.md
+++ b/docs/dev/plans/README.md
@@ -9,6 +9,7 @@ The format these follow, and the rule for what earns a doc here, live in [.claud
 ## Foundation
 
 - [Reikai → Mihon rebase overview](rebase-overview.md): why Reikai moved off Yōkai onto Mihon, the phased structure (P0-P9), the `// RK` patch convention, and the decisions behind it.
+- [Legacy Yōkai database import](legacy-yokai-import.md): recovering a user's manga + novel library when they update in place from a pre-rebase Yōkai build, instead of crashing on the now-incompatible shared `tachiyomi.db`.
 
 ## Library & shell
 

--- a/docs/dev/plans/legacy-yokai-import.md
+++ b/docs/dev/plans/legacy-yokai-import.md
@@ -1,0 +1,49 @@
+# Legacy Yōkai database import
+
+## Goal
+
+When a user updates in place from an old Yōkai-based build (the pre-rebase `1.9.x` line) to a Mihon-based Reikai, recover their manga and novel libraries, plus their extension repositories, automatically on first launch instead of crashing on startup.
+
+## Why
+
+Reikai keeps the same `applicationId` (`eu.kanade.tachiyomi` + `.y2k`) and an ever-climbing `versionCode` across the Yōkai → Mihon rebase so existing installs upgrade in place. But the two forks share the same database file name, `tachiyomi.db`, with **independent and now-crossed schema version numbers**: the Yōkai schema sits at version ~40 (migrations up to `39.sqm` on the `design/library-compose` branch), while Mihon's is ~27 (migrations up to `26.sqm`). SQLDelight's driver compares the on-disk version against the code's schema version; because the Yōkai DB reports a *higher* number, it concludes the database is newer than the code, runs **no** migrations, and then queries a Yōkai-shaped DB through Mihon's tables. The first query hits a table Yōkai never had (`extension_store`) and the app crashes before any UI draws.
+
+This affected every existing Yōkai-Y2K user updating to a Mihon-based release (both 0.1.0 and 0.1.1), reported as [unseensnick/Reikai#11](https://github.com/unseensnick/Reikai/issues/11) (surfaced as a Xiaomi/MIUI crash dialog, but not device-specific). Fresh installs and Mihon-era upgrades (0.1.0 → 0.1.1) are unaffected, which is why the separately-packaged preview build (a fresh `.debug` install) appeared to "work".
+
+## Approach
+
+On launch, before the app opens its database, peek at the existing `tachiyomi.db`. If it's a legacy Yōkai one, read the library out with plain SQL, package it into a normal backup file using the app's own backup model classes, move the old DB aside (renamed, never deleted), let SQLDelight create a fresh empty DB so the crash can't happen, then feed the backup through the existing, already-proven restore pipeline. The user lands in a working app with their library restored.
+
+Settings and tracker logins are untouched: those live in SharedPreferences, which survive an in-place update, so only the database content needs recovering.
+
+Mechanism:
+
+- **Detection** is by schema signature, not version number, so it never false-positives on a Mihon DB: Yōkai's `categories` table carries a `manga_order` column that Mihon's never has.
+- **Extraction** runs read-only raw SQL over the legacy tables (`mangas`, `chapters`, `categories`, `mangas_categories`, `history`, `manga_sync`, and the `novel*` equivalents) and builds Mihon's `Backup*` objects directly. Because the backup is built with Mihon's own classes, there is no proto-version compatibility concern; column reads are tolerant of older Yōkai DBs missing newer columns. Only favorited entries (the library) are taken.
+- **Extension repos** are read from the old `extension_repos` table (which Mihon's migration `11.sqm` would normally convert, but the whole chain was skipped, so it is still present) and converted to the current `extension_store` schema, mirroring that migration (`index_url = base_url + "/repo.json"`, legacy flag set). They restore via `RestoreOptions(extensionStores = true)`. Extensions themselves are not reinstalled: they are separate packages that survive an in-place update and are rediscovered at startup.
+- **Merges land flat.** Merge groups live in SharedPreferences keyed by id, which survive the in-place update, but the reset reassigns ids, so the stale id pairs would collide and wrongly group (or hide) unrelated entries. The importer clears all merge/unmerge prefs and disables same-title auto-merge, so the migrated library shows every entry in all its categories. The user re-merges in-app. This is migration-only (it runs solely from the legacy-DB path), so a normal restore on a fresh install is untouched.
+- **Reset** moves `tachiyomi.db` (and its `-wal`/`-shm`) to `tachiyomi.db.yokai.bak` so a failed extraction still stops the crash and the original data stays recoverable.
+- **Restore** writes the backup to a temp `.tachibk` (gzipped protobuf, same as `BackupCreator`) and enqueues `BackupRestoreJob` once DI and the fresh DB are ready, with a one-time toast.
+
+Because the crash happens at query time before anything writes, an already-bricked 0.1.0/0.1.1 install still has its Yōkai tables intact, so updating to the fixed build recovers it.
+
+## Key files
+
+- `app/src/main/java/reikai/data/legacy/LegacyYokaiDbImporter.kt` — detection, extraction, backup write, DB-aside.
+- `app/src/main/java/eu/kanade/tachiyomi/App.kt` — `// RK` islands in `onCreate`: `prepareIfLegacyDb` before the DB is first opened, restore enqueue (with `extensionStores = true`) at the end.
+- `i18n/.../base/strings.xml` — `legacy_import_notice`.
+- Reuses `eu.kanade.tachiyomi.data.backup.models.*`, `BackupRestoreJob`, `RestoreOptions`, `ReikaiLibraryPreferences`.
+
+## Status
+
+Shipped in 0.1.2. Verified on the emulator end to end, both with a synthetic Yōkai DB and with a real Yōkai-era backup: the crash reproduces on 0.1.0, and updating to the fixed build recovers the library (266 manga and 2 extension repos in the real-data run) with chapters, read state, categories, history, and tracking; the old DB is preserved as `.yokai.bak`; a fresh DB is created (`extension_store` present, no crash); and the library renders flat, every entry visible in its categories with no manga hidden by stale merges.
+
+## Decisions & tradeoffs
+
+- **Recover via backup/restore, not a schema migration.** Translating the Yōkai schema into Mihon's in place is the large, risky work the rebase deliberately avoided. Reusing the proven restore pipeline is smaller and safer, and the backup proto is already compatible across the rebase (a Yōkai backup file restores into Mihon).
+- **Signature detection, not version comparison.** The `manga_order` column is a driver-agnostic marker, robust regardless of how the SQLite driver stores its version, and cannot match a Mihon DB.
+- **Reset on extraction failure, but never delete.** The priority is to stop the crash; the old DB is renamed aside so data is always recoverable.
+- **`android.util.Log`, not the `logcat` extension.** The importer runs before `LogcatLogger` is installed in `App.onCreate`, so the extension would silently drop its lines.
+- **Migrate extension repos, not extensions.** The repo list carries over so the user keeps updating/adding sources. Extensions themselves are not reinstalled: they are separate packages that survive an in-place update, so sources resolve on a real device, and a reinstall from a snapshot of the installed set would be a no-op (recorded equals installed).
+- **Land the migrated library unmerged.** Preserving merges across an id reset is fragile: stale id pairs collide, and a merged group displays under a single member so other members' categories look empty. Clearing merges and disabling same-title auto-merge guarantees every entry is visible; users re-merge in-app. This was chosen over remapping merges to `{url, source}` refs, which still left categories looking sparse because of the single-representative display.
+- **Library only.** Reading history for Yōkai novels isn't carried (Yōkai stored novel progress on the chapter row, which is preserved, not in a history table); per-manga reading-mode flags ride the packed `viewer` value through unchanged.

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -692,6 +692,8 @@
     <string name="restoring_backup">Restoring backup</string>
     <string name="restoring_backup_error">Restoring backup failed</string>
     <string name="restoring_backup_canceled">Canceled restore</string>
+    <!-- RK: shown once on first launch after updating in place from the old Yōkai-based build -->
+    <string name="legacy_import_notice">Restoring your library from the previous version…</string>
     <string name="backup_info">You should keep copies of backups in other places as well. Backups may contain sensitive data including any stored passwords; be careful if sharing.</string>
     <string name="last_auto_backup_info">Last automatically backed up: %s</string>
     <string name="label_data">Data</string>


### PR DESCRIPTION
Fixes #11.

## What

Updating in place from a pre-rebase Yōkai-Y2K build (1.9.x) crashed on launch. Both forks share the `tachiyomi.db` file but number their SQLDelight schemas independently, and they have crossed over: the Yōkai DB reports a higher version than Mihon's, so the driver runs no migrations and the first query hits a table Yōkai never had (`extension_store`), crashing before any UI draws. This bricked every existing Yōkai install that updated to a Mihon-based release (0.1.0 and 0.1.1 alike); it surfaced as a Xiaomi/MIUI crash dialog but is not device-specific.

## How

On first launch the app detects a legacy Yōkai database (by a schema signature), recovers it, and continues normally:

- Reads the old manga and novel library with plain SQL and rebuilds it through the existing backup-restore pipeline (chapters, read state, history, categories, tracking).
- Migrates extension repositories, converted to the current repo schema (mirroring Mihon's `11.sqm`). Extensions themselves persist as separate packages.
- Lands the library unmerged (clears merge prefs, disables same-title auto-merge) so no entries are hidden by stale id-keyed merge data after the id reset.
- Moves the old DB aside (renamed, never deleted) so a fresh DB is created and the data stays recoverable.
- Installs already crashing on 0.1.0 / 0.1.1 are recovered too, since the crash happened before anything was written.

All of this is gated on detecting the legacy DB, so a normal restore on a fresh 0.1.1 install is untouched.

Cuts 0.1.2 (versionName/versionCode bumped; no tag, that is created manually on build).

## Verification

Verified on-device end to end with a real Yōkai-era backup: reproduced the crash on 0.1.0, then updated to this build, which recovered 266 manga and 2 extension repositories with no crash and every entry visible in its categories. Also covered with a synthetic Yōkai DB exercising the novel path.

Full write-up: `docs/dev/plans/legacy-yokai-import.md`.
