### PR TITLE
Migrate from the update-errors screen; re-trust extensions after repos added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Reikai uses its own [Semantic Versioning](https://semver.org/) from the Mihon-ba
 
 ## [Unreleased]
 
+### Additions
+
+- **Migrate failing entries from the update-errors screen.** Select entries that failed their last update (the update-errors list), tap Migrate, and they go straight into the migration flow to move them onto a working source. ([#15](https://github.com/unseensnick/Reikai/issues/15))
+
 ## [0.1.2]
 
 ### Additions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Reikai uses its own [Semantic Versioning](https://semver.org/) from the Mihon-ba
 
 ## [Unreleased]
 
+## [0.1.3]
+
 ### Additions
 
 - **Migrate failing entries from the update-errors screen.** Select entries that failed their last update (the update-errors list), tap Migrate, and they go straight into the migration flow to move them onto a working source. The list is opt-in: turn on Settings → Advanced → Track manga update errors and Track novel update errors first, then open it from the library overflow menu. ([#15](https://github.com/unseensnick/Reikai/issues/15))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,11 @@ Reikai uses its own [Semantic Versioning](https://semver.org/) from the Mihon-ba
 
 ### Additions
 
-- **Migrate failing entries from the update-errors screen.** Select entries that failed their last update (the update-errors list), tap Migrate, and they go straight into the migration flow to move them onto a working source. ([#15](https://github.com/unseensnick/Reikai/issues/15))
+- **Migrate failing entries from the update-errors screen.** Select entries that failed their last update (the update-errors list), tap Migrate, and they go straight into the migration flow to move them onto a working source. The list is opt-in: turn on Settings → Advanced → Track manga update errors and Track novel update errors first, then open it from the library overflow menu. ([#15](https://github.com/unseensnick/Reikai/issues/15))
+
+### Fixes
+
+- **Extensions re-trust themselves once their repository is present.** After updating from an old build, restoring a backup, or adding a repository by hand, installed extensions no longer stay "untrusted" until you restart the app: they re-check automatically as soon as the repository lands. A "Re-check extensions" action in the Browse → Extensions overflow menu can trigger the same re-check on demand. ([#14](https://github.com/unseensnick/Reikai/issues/14))
 
 ## [0.1.2]
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -39,8 +39,8 @@ android {
         // versionCode must keep climbing and stay above the last Yokai-based build (168) so installs upgrade in place.
         applicationId = "eu.kanade.tachiyomi"
 
-        versionCode = 172
-        versionName = "0.1.2"
+        versionCode = 173
+        versionName = "0.1.3"
         // RK <--
 
         buildConfigField("String", "COMMIT_COUNT", "\"${getLatestCommitCount()}\"")

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/browse/ExtensionStoresScreenModel.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/browse/ExtensionStoresScreenModel.kt
@@ -80,6 +80,9 @@ class ExtensionStoresScreenModel(
             addExtensionStore(baseUrl)
                 .onSuccess {
                     extensionManager.findAvailableExtensions()
+                    // RK: re-trust installed extensions against the just-added repo, so any that were
+                    // loaded Untrusted (no matching repo at startup) become trusted without a restart.
+                    extensionManager.reloadInstalledExtensions()
                     dismissDialog()
                 }
                 .onFailure { throwable ->

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/BackupRestorer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/BackupRestorer.kt
@@ -16,6 +16,7 @@ import eu.kanade.tachiyomi.data.backup.restore.restorers.ExtensionStoreRestorer
 import eu.kanade.tachiyomi.data.backup.restore.restorers.MangaRestorer
 import eu.kanade.tachiyomi.data.backup.restore.restorers.NovelRestorer
 import eu.kanade.tachiyomi.data.backup.restore.restorers.PreferenceRestorer
+import eu.kanade.tachiyomi.extension.ExtensionManager
 import eu.kanade.tachiyomi.util.system.createFileInCacheDir
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.coroutineScope
@@ -49,6 +50,7 @@ class BackupRestorer(
     // RK -->
     private val novelRestorer: NovelRestorer = NovelRestorer(),
     private val extensionRestorer: ExtensionRestorer = ExtensionRestorer(),
+    private val extensionManager: ExtensionManager = Injekt.get(),
     // RK <--
 ) {
 
@@ -142,6 +144,14 @@ class BackupRestorer(
             // RK <--
 
             // TODO: optionally trigger online library + tracker update
+        }
+
+        // RK: trust is evaluated once at startup, before this restore populated the repo list, so any
+        // extension installed at that point (e.g. carried over from an in-place Yōkai upgrade) loaded
+        // Untrusted. Now that the repos exist, re-scan installed extensions so they re-trust without
+        // an app restart.
+        if (options.extensionStores) {
+            extensionManager.reloadInstalledExtensions()
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/extension/ExtensionManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/extension/ExtensionManager.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.flow.stateIn
 import exh.source.BlacklistedSources
 import exh.source.ExhPreferences
 import logcat.LogPriority
+import tachiyomi.core.common.util.lang.launchIO
 import tachiyomi.core.common.util.lang.withUIContext
 import tachiyomi.core.common.util.system.logcat
 import tachiyomi.domain.source.model.StubSource
@@ -135,6 +136,20 @@ class ExtensionManager(
 
         _isInitialized.value = true
     }
+
+    // RK -->
+    /**
+     * Re-runs the installed scan and trust evaluation against the current repos.
+     *
+     * Trust is otherwise only evaluated once, in [init], which fires before an async backup restore
+     * (or a manual repo add) can populate the repo list. Extensions installed at that point load
+     * Untrusted and never re-evaluate until the next launch. Call this once repos have changed so
+     * they re-trust without a restart.
+     */
+    fun reloadInstalledExtensions() {
+        scope.launchIO { initExtensions() }
+    }
+    // RK <--
 
     /**
      * Finds the available extensions in the [api] and updates [availableExtensionMapFlow].

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/extension/ExtensionsScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/extension/ExtensionsScreenModel.kt
@@ -207,6 +207,12 @@ class ExtensionsScreenModel(
         }
     }
 
+    // RK: manual lever to re-scan installed extensions and re-evaluate trust against the current
+    // repos (for the rare case an extension is stuck Untrusted after its repo was added).
+    fun reloadInstalledExtensions() {
+        extensionManager.reloadInstalledExtensions()
+    }
+
     @Immutable
     data class State(
         val isLoading: Boolean = true,

--- a/app/src/main/java/reikai/presentation/browse/extension/LnPluginManagerScreenModel.kt
+++ b/app/src/main/java/reikai/presentation/browse/extension/LnPluginManagerScreenModel.kt
@@ -94,6 +94,15 @@ class LnPluginManagerScreenModel(
         }
     }
 
+    /**
+     * Force a re-load of the installed novel plugins (retrying any that failed). The novel twin of
+     * manga's ExtensionManager.reloadInstalledExtensions(), wired into the shared "Re-check
+     * extensions" action on this tab so it re-checks both verticals.
+     */
+    fun reloadInstalled() {
+        screenModelScope.launchIO { installer.loadInstalled() }
+    }
+
     fun install(entry: LnRegistryEntry) {
         val key = canonicalizePluginUrl(entry.url)
         screenModelScope.launchIO {

--- a/app/src/main/java/reikai/presentation/browse/extension/ReikaiExtensionsTab.kt
+++ b/app/src/main/java/reikai/presentation/browse/extension/ReikaiExtensionsTab.kt
@@ -64,6 +64,17 @@ fun Screen.reikaiExtensionsTab(
                 title = stringResource(MR.strings.repos),
                 onClick = openRepos,
             ),
+            // Re-check both verticals on this unified tab: re-scan installed manga extensions and
+            // re-evaluate trust against the current repos (recovers extensions stuck Untrusted after
+            // their repo was added post-startup), and force-reload the installed novel plugins
+            // (retrying any that failed to load).
+            AppBar.OverflowAction(
+                title = stringResource(MR.strings.action_recheck_extensions),
+                onClick = {
+                    extensionsScreenModel.reloadInstalledExtensions()
+                    lnModel.reloadInstalled()
+                },
+            ),
         ),
         content = { contentPadding, snackbarHostState ->
             // The shared Browse search bar drives extensionsScreenModel (manga only); apply the same

--- a/app/src/main/java/reikai/presentation/library/updateerror/UpdateErrorsScreen.kt
+++ b/app/src/main/java/reikai/presentation/library/updateerror/UpdateErrorsScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -13,6 +14,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.icons.outlined.Refresh
 import androidx.compose.material.icons.outlined.SelectAll
+import androidx.compose.material.icons.outlined.SwapCalls
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -31,10 +33,12 @@ import eu.kanade.presentation.components.AppBarActions
 import eu.kanade.presentation.manga.components.MangaCover
 import eu.kanade.presentation.util.Screen
 import eu.kanade.tachiyomi.ui.manga.MangaScreen
+import mihon.feature.migration.config.MigrationConfigScreen
 import reikai.data.coil.NovelCover
 import reikai.domain.library.ContentType
 import reikai.presentation.components.ContentTypeFilterChips
 import reikai.presentation.novel.details.NovelScreen
+import reikai.presentation.novel.migrate.NovelMigrationConfigScreen
 import tachiyomi.domain.manga.model.MangaCover as MangaCoverData
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.components.material.Scaffold
@@ -76,6 +80,21 @@ class UpdateErrorsScreen(
                                     title = stringResource(MR.strings.action_select_all),
                                     icon = Icons.Outlined.SelectAll,
                                     onClick = screenModel::selectAll,
+                                ),
+                                AppBar.Action(
+                                    title = stringResource(MR.strings.action_migrate),
+                                    icon = Icons.Outlined.SwapCalls,
+                                    enabled = successState.selectionIsSingleVertical,
+                                    onClick = {
+                                        val mangaIds = screenModel.selectedMangaIds()
+                                        val novelIds = screenModel.selectedNovelIds()
+                                        if (mangaIds.isNotEmpty()) {
+                                            navigator.push(MigrationConfigScreen(mangaIds))
+                                        } else if (novelIds.isNotEmpty()) {
+                                            navigator.push(NovelMigrationConfigScreen(novelIds))
+                                        }
+                                        screenModel.clearSelection()
+                                    },
                                 ),
                                 AppBar.Action(
                                     title = stringResource(MR.strings.action_delete),
@@ -187,6 +206,7 @@ private fun UpdateErrorRow(
     }
     Row(
         modifier = Modifier
+            .fillMaxWidth()
             .selectedBackground(isSelected)
             .height(56.dp)
             .combinedClickable(onClick = onClick, onLongClick = onLongClick)

--- a/app/src/main/java/reikai/presentation/library/updateerror/UpdateErrorsScreenModel.kt
+++ b/app/src/main/java/reikai/presentation/library/updateerror/UpdateErrorsScreenModel.kt
@@ -91,7 +91,7 @@ class UpdateErrorsScreenModel(
 
     fun dismissSelected() {
         val state = state.value as? UpdateErrorsScreenState.Success ?: return
-        val selectedEntries = state.entries.filter { it.key in state.selected }
+        val selectedEntries = state.selectedEntries
         if (selectedEntries.isEmpty()) return
         val mangaIds = selectedEntries.filterIsInstance<UpdateErrorEntry.Manga>().map { it.error.errorId }
         val novelIds = selectedEntries.filterIsInstance<UpdateErrorEntry.Novel>().map { it.error.errorId }
@@ -99,6 +99,18 @@ class UpdateErrorsScreenModel(
             if (mangaIds.isNotEmpty()) deleteLibraryUpdateErrors.byErrorIds(mangaIds)
             if (novelIds.isNotEmpty()) deleteNovelUpdateErrors.byErrorIds(novelIds)
         }
+    }
+
+    /** The manga ids of the current selection (their library ids, for migration). */
+    fun selectedMangaIds(): List<Long> {
+        val state = state.value as? UpdateErrorsScreenState.Success ?: return emptyList()
+        return state.selectedEntries.filterIsInstance<UpdateErrorEntry.Manga>().map { it.error.mangaId }
+    }
+
+    /** The novel ids of the current selection (their library ids, for migration). */
+    fun selectedNovelIds(): List<Long> {
+        val state = state.value as? UpdateErrorsScreenState.Success ?: return emptyList()
+        return state.selectedEntries.filterIsInstance<UpdateErrorEntry.Novel>().map { it.error.novelId }
     }
 
     fun dismissAll() {
@@ -138,6 +150,15 @@ sealed interface UpdateErrorsScreenState {
             .map { (message, items) -> UpdateErrorGroup(message, items) }
         val isEmpty: Boolean get() = visibleEntries.isEmpty()
         val selectionMode: Boolean get() = selected.isNotEmpty()
+        val selectedEntries: List<UpdateErrorEntry> get() = entries.filter { it.key in selected }
+
+        /** True when the selection is non-empty and all one vertical. Migration runs one vertical
+         *  at a time, so a mixed manga + novel selection can't be migrated together. */
+        val selectionIsSingleVertical: Boolean get() {
+            val hasManga = selectedEntries.any { it is UpdateErrorEntry.Manga }
+            val hasNovel = selectedEntries.any { it is UpdateErrorEntry.Novel }
+            return hasManga != hasNovel
+        }
     }
 }
 

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -472,6 +472,8 @@
 
     <!-- Extension store -->
     <string name="extensionStores">Extension stores</string>
+    <!-- RK: overflow action to re-scan installed extensions and re-evaluate trust against current repos -->
+    <string name="action_recheck_extensions">Re-check extensions</string>
     <!-- RK: the Repos screen counts manga + light-novel repositories -->
     <string name="extension_repos_subtitle">%1$d manga, %2$d light novel</string>
     <string name="action.addExtensionStore">Add extension store</string>


### PR DESCRIPTION
Two follow-ups to the Yōkai to Mihon migration fix.

## Migrate failing entries from the update-errors screen (#15)

Select entries that failed their last update and send them straight into migration to move them onto a working source, without opening each one first.

- Migrate action in the update-errors selection bar; single-vertical selection only (all manga or all novels), greyed out for a mixed selection since migration runs one vertical at a time.
- A replace-migration unfavorites the failing source, so its error row drops off the list on its own.
- Rows now fill the available width, and the action uses the app's swap migrate icon.
- The update-errors list is opt-in: turn on Settings > Advanced > Track manga update errors and Track novel update errors, then open it from the library overflow menu.

## Re-trust extensions after repos are added (#14)

After updating from an old build, restoring a backup, or adding a repository by hand, installed extensions stayed "untrusted" until an app restart. They now re-check and trust themselves as soon as the repository is present.

- Re-scans installed extensions after a restore that includes repositories (covers the in-place Yōkai upgrade path and a normal backup restore) and after a manual repo add.
- New "Re-check extensions" action in the Browse > Extensions overflow re-checks both verticals: manga extension trust and installed novel plugins.

Under the hood: new ExtensionManager.reloadInstalledExtensions() re-runs the installed scan and trust evaluation against the current repos, off the main thread; trust was otherwise only evaluated once at startup.

Verified on-device: migrate opens from the update-errors screen and a completed replace-migration drops the entry from the list; an installed extension transitions untrusted to trusted after its repo is added, with no restart.