### PR TITLE
Merge all sources of a series in one tap (0.1.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Reikai uses its own [Semantic Versioning](https://semver.org/) from the Mihon-ba
 
 ## [Unreleased]
 
+### Fixes
+
+- **Merging a series' sources now takes one tap.** Selecting the cards for the same series from different sources and tapping Merge now combines all of them at once, including same-title copies that were auto-grouped, instead of needing several taps to fully coalesce. Most noticeable after restoring a backup. Applies to both the manga and novel libraries.
+
 ## [0.1.4]
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Reikai uses its own [Semantic Versioning](https://semver.org/) from the Mihon-ba
 
 ## [Unreleased]
 
+## [0.1.5]
+
 ### Fixes
 
 - **Merging a series' sources now takes one tap.** Selecting the cards for the same series from different sources and tapping Merge now combines all of them at once, including same-title copies that were auto-grouped, instead of needing several taps to fully coalesce. Most noticeable after restoring a backup. Applies to both the manga and novel libraries.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -39,8 +39,8 @@ android {
         // versionCode must keep climbing and stay above the last Yokai-based build (168) so installs upgrade in place.
         applicationId = "eu.kanade.tachiyomi"
 
-        versionCode = 174
-        versionName = "0.1.4"
+        versionCode = 175
+        versionName = "0.1.5"
         // RK <--
 
         buildConfigField("String", "COMMIT_COUNT", "\"${getLatestCommitCount()}\"")

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
@@ -963,9 +963,12 @@ class LibraryScreenModel(
     fun mergeSelection() {
         val ids = state.value.selection.toList()
         if (ids.size < 2) return
-        mergeManager.mergeManga(ids)
-        // RK: share any existing tracker across the newly merged group
-        screenModelScope.launchIO { propagateTrackerLinks.fromSeed(ids.first()) }
+        screenModelScope.launchIO {
+            // RK: expand each selected card to its full group first, so one merge coalesces every source
+            mergeManager.mergeSelectedManga(ids)
+            // RK: share any existing tracker across the newly merged group
+            propagateTrackerLinks.fromSeed(ids.first())
+        }
         clearSelection()
     }
 

--- a/app/src/main/java/exh/eh/EHentaiUpdateHelper.kt
+++ b/app/src/main/java/exh/eh/EHentaiUpdateHelper.kt
@@ -123,7 +123,7 @@ class EHentaiUpdateHelper(context: Context) {
             )
 
             // Delete the duplicate history first
-            // RK: by-id batch reset (Komikku's removeHistory(List)); see RemoveHistory.await(List).
+            // by-id batch reset (Komikku's removeHistory(List)); see RemoveHistory.await(List).
             removeHistory.await(deleteHistory)
 
             // Insert new history
@@ -131,7 +131,7 @@ class EHentaiUpdateHelper(context: Context) {
                 upsertHistory.await(it)
             }
 
-            // RK: Komikku also upserts a FavoriteEntryAlternative here for its favorites two-way
+            // Komikku also upserts a FavoriteEntryAlternative here for its favorites two-way
             //     sync (5b). Omitted until that phase ships; reconciliation works without it.
 
             // Copy categories from all chains to accepted manga

--- a/app/src/main/java/exh/eh/EHentaiUpdateWorker.kt
+++ b/app/src/main/java/exh/eh/EHentaiUpdateWorker.kt
@@ -196,7 +196,7 @@ class EHentaiUpdateWorker(private val context: Context, workerParams: WorkerPara
             ?: throw GalleryNotUpdatedException(false, IllegalStateException("Missing EH-based source (${manga.source})!"))
 
         try {
-            // RK: Komikku splits getMangaDetails + getChapterList; Reikai's source-api combines them.
+            // Komikku splits getMangaDetails + getChapterList; Reikai's source-api combines them.
             val update = source.getMangaUpdate(manga.toSManga(), emptyList(), fetchDetails = true, fetchChapters = true)
             updateManga.awaitAll(listOf(manga.copyFrom(update.manga).toMangaUpdate()))
 

--- a/app/src/main/java/exh/source/EhMangaUtil.kt
+++ b/app/src/main/java/exh/source/EhMangaUtil.kt
@@ -2,5 +2,5 @@ package exh.source
 
 import tachiyomi.domain.manga.model.Manga
 
-// RK: true for galleries from a built-in E-Hentai / ExHentai source (favorites backup gating).
+// true for galleries from a built-in E-Hentai / ExHentai source (favorites backup gating).
 fun Manga.isEhBasedManga(): Boolean = source in eHentaiSourceIds

--- a/app/src/main/java/reikai/domain/manga/MangaMergeManager.kt
+++ b/app/src/main/java/reikai/domain/manga/MangaMergeManager.kt
@@ -151,6 +151,34 @@ class MangaMergeManager(
     }
 
     /**
+     * Merge the library selection into one group. Each selected id is first expanded to its full
+     * resolved group (manual-merge members + same-title favorites when auto-merge is on, minus
+     * existing unmerges), because the library shows one collapsed card per group and a selection only
+     * carries each card's representative id. Without this, merging two collapsed cards records only
+     * the two representatives and strands their hidden same-title members, forcing repeated merges.
+     * Migration calls [mergeManga] directly with an already-resolved id list, so it stays unexpanded.
+     */
+    suspend fun mergeSelectedManga(ids: List<Long>) {
+        val merges = preferences.mangaManualMerges.get()
+        val unmerges = preferences.mangaManualUnmerges.get()
+        val favorites = if (preferences.autoMergeSameTitle.get()) getFavorites.await() else emptyList()
+        val expanded = ids.distinct().flatMapTo(LinkedHashSet<Long>()) { id ->
+            val title = favorites.firstOrNull { it.id == id }?.title?.trim()?.lowercase().orEmpty()
+            MergeGroupAlgebra.computeGroupIds(id, merges, sameTitleIds(favorites, title), unmerges).toList()
+        }
+        mergeManga(expanded.toList())
+    }
+
+    /** Favorited manga ids sharing [title] (already lowercased/trimmed); empty for a blank title. */
+    private fun sameTitleIds(favorites: List<Manga>, title: String): Set<Long> {
+        if (title.isEmpty()) return emptySet()
+        return favorites.asSequence()
+            .filter { it.title.trim().equals(title, ignoreCase = true) }
+            .map { it.id }
+            .toSet()
+    }
+
+    /**
      * Fully dissolve the merge group of each of [targetIds] (the library bulk "Unmerge"): every
      * member of the group is separated in one pass, so the user does not have to unmerge a group
      * source-by-source. Each target's group is resolved against the CURRENT prefs (so dissolving one
@@ -169,15 +197,7 @@ class MangaMergeManager(
             val merges = preferences.mangaManualMerges.get()
             val unmerges = preferences.mangaManualUnmerges.get()
             val sameTitle = if (autoSameTitle) {
-                val title = favorites.firstOrNull { it.id == target }?.title?.trim()?.lowercase().orEmpty()
-                if (title.isEmpty()) {
-                    emptySet()
-                } else {
-                    favorites.asSequence()
-                        .filter { it.title.trim().equals(title, ignoreCase = true) }
-                        .map { it.id }
-                        .toSet()
-                }
+                sameTitleIds(favorites, favorites.firstOrNull { it.id == target }?.title?.trim()?.lowercase().orEmpty())
             } else {
                 emptySet()
             }

--- a/app/src/main/java/reikai/domain/novel/NovelMergeManager.kt
+++ b/app/src/main/java/reikai/domain/novel/NovelMergeManager.kt
@@ -61,6 +61,26 @@ class NovelMergeManager(
     }
 
     /**
+     * Merge the library selection into one group. Each selected id is first expanded to its full
+     * resolved group (manual-merge members + author-guarded same-title favorites, minus existing
+     * unmerges), because the library shows one collapsed card per group and a selection only carries
+     * each card's representative id. Without this, merging two collapsed cards records only the two
+     * representatives and strands their hidden same-title members, forcing repeated merges. Migration
+     * calls [mergeNovels] directly with an already-resolved id list, so it stays unexpanded.
+     */
+    suspend fun mergeSelectedNovels(ids: List<Long>) {
+        val merges = preferences.novelManualMerges.get()
+        val unmerges = preferences.novelManualUnmerges.get()
+        val favorites = if (preferences.novelAutoMergeSameTitle.get()) novelRepository.getFavorites() else emptyList()
+        val expanded = ids.distinct().flatMapTo(LinkedHashSet<Long>()) { id ->
+            val novel = favorites.firstOrNull { it.id == id }
+            val sameTitle = sameTitleIds(favorites, novel?.title?.trim()?.lowercase().orEmpty(), novel?.author)
+            MergeGroupAlgebra.computeGroupIds(id, merges, sameTitle, unmerges).toList()
+        }
+        mergeNovels(expanded.toList())
+    }
+
+    /**
      * Fully dissolve the merge group of each of [targetIds] (the library bulk "Unmerge"): every member
      * is separated in one pass, including same-title auto-grouped members, so nothing regroups on the
      * next resolution. Targets not in a group are skipped.

--- a/app/src/main/java/reikai/novel/host/LnHostBridge.kt
+++ b/app/src/main/java/reikai/novel/host/LnHostBridge.kt
@@ -30,7 +30,7 @@ import tachiyomi.core.common.util.system.logcat
 class LnHostBridge(
     private val preferenceStore: PreferenceStore,
     private val client: OkHttpClient,
-    // RK: the device's real WebView User-Agent (see [LnPluginHost]); empty when unavailable.
+    // the device's real WebView User-Agent (see [LnPluginHost]); empty when unavailable.
     private val userAgent: String = "",
 ) {
 

--- a/app/src/main/java/reikai/novel/host/LnPluginHost.kt
+++ b/app/src/main/java/reikai/novel/host/LnPluginHost.kt
@@ -44,7 +44,7 @@ class LnPluginHost(
 
     private val appContext = context.applicationContext
 
-    // RK: the device's real WebView User-Agent (real model + Android + Chrome version), like LNReader.
+    // the device's real WebView User-Agent (real model + Android + Chrome version), like LNReader.
     // Mihon's network client otherwise defaults to a stripped generic "Android 10; K" UA that some LN
     // sources answer with a degraded page (e.g. Novel Bin serves 200x89 thumbnail covers to it).
     private val deviceUserAgent: String =

--- a/app/src/main/java/reikai/presentation/library/ReikaiComfortableGridPanoramaItem.kt
+++ b/app/src/main/java/reikai/presentation/library/ReikaiComfortableGridPanoramaItem.kt
@@ -32,7 +32,7 @@ import eu.kanade.presentation.manga.components.MangaCover
  */
 @Composable
 fun ReikaiComfortableGridPanoramaItem(
-    coverData: Any, // RK: Any (not MangaCover) so reikai.data.coil.NovelCover renders here too
+    coverData: Any, // Any (not MangaCover) so reikai.data.coil.NovelCover renders here too
     title: String,
     onClick: () -> Unit,
     onLongClick: () -> Unit,

--- a/app/src/main/java/reikai/presentation/library/ReikaiLibraryBadges.kt
+++ b/app/src/main/java/reikai/presentation/library/ReikaiLibraryBadges.kt
@@ -103,7 +103,7 @@ fun SourceIconBadge(source: Source?) {
             color = MaterialTheme.colorScheme.tertiary,
             iconColor = MaterialTheme.colorScheme.onTertiary,
         )
-        // RK: built-in E-Hentai / ExHentai ship no extension icon, so draw the EH mark on a white
+        // built-in E-Hentai / ExHentai ship no extension icon, so draw the EH mark on a white
         //     tile (same treatment as the browse SourceIcon) instead of the generic library glyph.
         source.id in eHentaiSourceIds -> EhSourceIconBadge()
         else -> Badge(

--- a/app/src/main/java/reikai/presentation/library/ReikaiLibraryComfortableGridPanorama.kt
+++ b/app/src/main/java/reikai/presentation/library/ReikaiLibraryComfortableGridPanorama.kt
@@ -45,7 +45,7 @@ fun ReikaiLibraryComfortableGridPanorama(
             ReikaiComfortableGridPanoramaItem(
                 isSelected = manga.id in selection,
                 title = manga.title,
-                coverData = libraryCoverModel(libraryItem), // RK: NovelCover for novels, else MangaCover
+                coverData = libraryCoverModel(libraryItem), // NovelCover for novels, else MangaCover
                 coverBadgeStart = {
                     DownloadsBadge(count = libraryItem.badges.downloadCount)
                     UnreadBadge(count = libraryItem.badges.unreadCount)
@@ -55,7 +55,7 @@ fun ReikaiLibraryComfortableGridPanorama(
                         isLocal = libraryItem.badges.isLocal,
                         sourceLanguage = libraryItem.badges.sourceLanguage,
                     )
-                    LibraryCoverEndBadge(libraryItem) // RK: merge / novel-icon / manga-icon
+                    LibraryCoverEndBadge(libraryItem) // merge / novel-icon / manga-icon
                 },
                 onLongClick = { onLongClick(libraryItem.libraryManga) },
                 onClick = { onClick(libraryItem.libraryManga) },

--- a/app/src/main/java/reikai/presentation/library/ReikaiLibraryContent.kt
+++ b/app/src/main/java/reikai/presentation/library/ReikaiLibraryContent.kt
@@ -136,13 +136,13 @@ fun ReikaiLibraryContent(
     onToggleDefaultCollapse: (String) -> Unit,
     onToggleDynamicCollapse: (String) -> Unit,
     onGlobalSearchClicked: () -> Unit,
-    // RK: pull down at the top of the single-list to update the whole library (overflow Update library).
+    // pull down at the top of the single-list to update the whole library (overflow Update library).
     onRefresh: () -> Boolean,
-    // RK 4.6: per-category header affordances (real categories only; dynamic groups opt out)
+    // per-category header affordances (real categories only; dynamic groups opt out)
     onClickCategorySort: (Category) -> Unit,
     onRefreshCategory: (Category) -> Unit,
     onSelectAllInCategory: (Category) -> Unit,
-    // RK: continue-reading button on covers, single-list parity with the pager; null = hidden
+    // continue-reading button on covers, single-list parity with the pager; null = hidden
     onClickContinueReading: ((LibraryManga) -> Unit)? = null,
 ) {
     val isList = displayMode is LibraryDisplayMode.List
@@ -252,7 +252,7 @@ fun ReikaiLibraryContent(
                         ) { libraryItem ->
                             val manga = libraryItem.libraryManga.manga
                             val isSelected = manga.id in selection
-                            val coverData = libraryCoverModel(libraryItem) // RK: NovelCover for novels, else MangaCover
+                            val coverData = libraryCoverModel(libraryItem) // NovelCover for novels, else MangaCover
                             val onClick = { onClickManga(category, libraryItem.libraryManga) }
                             val onLongClick = { onLongClickManga(category, libraryItem.libraryManga) }
                             // Show the play button only when there's something unread (matches the pager).
@@ -276,7 +276,7 @@ fun ReikaiLibraryContent(
                                             isLocal = libraryItem.badges.isLocal,
                                             sourceLanguage = libraryItem.badges.sourceLanguage,
                                         )
-                                        LibraryCoverEndBadge(libraryItem) // RK: merge / novel-icon / manga-icon
+                                        LibraryCoverEndBadge(libraryItem) // merge / novel-icon / manga-icon
                                     },
                                     isSelected = isSelected,
                                 )
@@ -296,7 +296,7 @@ fun ReikaiLibraryContent(
                                             isLocal = libraryItem.badges.isLocal,
                                             sourceLanguage = libraryItem.badges.sourceLanguage,
                                         )
-                                        LibraryCoverEndBadge(libraryItem) // RK: merge / novel-icon / manga-icon
+                                        LibraryCoverEndBadge(libraryItem) // merge / novel-icon / manga-icon
                                     },
                                 )
                                 // Panorama: same uniform Book-height cell, wide covers shown whole (letterboxed).
@@ -316,7 +316,7 @@ fun ReikaiLibraryContent(
                                             isLocal = libraryItem.badges.isLocal,
                                             sourceLanguage = libraryItem.badges.sourceLanguage,
                                         )
-                                        LibraryCoverEndBadge(libraryItem) // RK: merge / novel-icon / manga-icon
+                                        LibraryCoverEndBadge(libraryItem) // merge / novel-icon / manga-icon
                                     },
                                 )
                                 // Compact grid (with title) and cover-only grid (title null) share a cell.
@@ -338,7 +338,7 @@ fun ReikaiLibraryContent(
                                             isLocal = libraryItem.badges.isLocal,
                                             sourceLanguage = libraryItem.badges.sourceLanguage,
                                         )
-                                        LibraryCoverEndBadge(libraryItem) // RK: merge / novel-icon / manga-icon
+                                        LibraryCoverEndBadge(libraryItem) // merge / novel-icon / manga-icon
                                     },
                                 )
                             }

--- a/app/src/main/java/reikai/presentation/library/novels/NovelLibraryScreenModel.kt
+++ b/app/src/main/java/reikai/presentation/library/novels/NovelLibraryScreenModel.kt
@@ -487,7 +487,8 @@ class NovelLibraryScreenModel :
         val ids = state.value.selectedNovelIds
         if (ids.size < 2) return
         screenModelScope.launchIO {
-            mergeManager.mergeNovels(ids)
+            // expand each selected card to its full group first, so one merge coalesces every source
+            mergeManager.mergeSelectedNovels(ids)
             clearSelection()
         }
     }
@@ -497,7 +498,7 @@ class NovelLibraryScreenModel :
         val ids = state.value.selectedNovelIds
         if (ids.isEmpty()) return
         screenModelScope.launchIO {
-            // RK: copy each group's trackers onto its members before splitting, so each keeps them (Active #8).
+            // copy each group's trackers onto its members before splitting, so each keeps them (Active #8).
             ids.forEach { propagateNovelTrackerLinks.fromSeed(it) }
             mergeManager.unmergeNovels(ids)
             clearSelection()

--- a/app/src/main/java/reikai/presentation/library/novels/NovelLibrarySettingsDialog.kt
+++ b/app/src/main/java/reikai/presentation/library/novels/NovelLibrarySettingsDialog.kt
@@ -256,7 +256,7 @@ private fun ColumnScope.NovelDisplayPage(screenModel: LibrarySettingsScreenModel
         label = stringResource(MR.strings.action_display_source_badge),
         pref = screenModel.reikaiLibraryPreferences.sourceBadge,
     )
-    // RK --> novel merge toggles (P5 S8)
+    // novel merge toggles (P5 S8)
     CheckboxItem(
         label = stringResource(MR.strings.action_merge_same_title),
         pref = screenModel.reikaiLibraryPreferences.novelAutoMergeSameTitle,
@@ -272,7 +272,6 @@ private fun ColumnScope.NovelDisplayPage(screenModel: LibrarySettingsScreenModel
         label = stringResource(MR.strings.action_merge_source_icons),
         pref = screenModel.reikaiLibraryPreferences.showNovelMergeSourceIcons,
     )
-    // RK <--
     CheckboxItem(
         label = stringResource(MR.strings.action_display_show_continue_reading_button),
         pref = screenModel.libraryPreferences.showContinueReadingButton,

--- a/app/src/main/java/reikai/presentation/novel/details/NovelDetailsScreenModel.kt
+++ b/app/src/main/java/reikai/presentation/novel/details/NovelDetailsScreenModel.kt
@@ -110,14 +110,13 @@ class NovelDetailsScreenModel(
     private val libraryPreferences: LibraryPreferences by injectLazy()
     private val context: Application by injectLazy()
 
-    // RK --> novel trackers (Active #8)
+    // novel trackers (Active #8)
     private val getNovelTracks: GetNovelTracks by injectLazy()
     private val refreshNovelTracks: RefreshNovelTracks by injectLazy()
     private val trackNovelChapter: TrackNovelChapter by injectLazy()
     private val trackerManager: TrackerManager by injectLazy()
     private val trackPreferences: TrackPreferences by injectLazy()
     private val propagateNovelTrackerLinks: PropagateNovelTrackerLinks by injectLazy()
-    // RK <--
 
     /** Hosts the merge split/remove Undo snackbars; wired into the details Scaffold. */
     val snackbarHostState = SnackbarHostState()
@@ -556,7 +555,7 @@ class NovelDetailsScreenModel(
         val prevMerges = reikaiLibraryPreferences.novelManualMerges.get()
         val prevUnmerges = reikaiLibraryPreferences.novelManualUnmerges.get()
         val prevRelated = relatedNovelIds.value
-        // RK: copy the group's trackers onto each member so a split source keeps them (Active #8).
+        // copy the group's trackers onto each member so a split source keeps them (Active #8).
         // Explicit ids (not a re-resolve), so it's race-free against the synchronous split below.
         screenModelScope.launchIO { propagateNovelTrackerLinks.distribute(prevRelated.toList()) }
         val newIds = mergeManager.splitOrDissolve(prevRelated, targetIds)
@@ -921,7 +920,7 @@ class NovelDetailsScreenModel(
         screenModelScope.launchIO { deleteNovelChaptersAfterRead.await(novelId, chapters) }
     }
 
-    // RK --> novel trackers (Active #8)
+    // novel trackers (Active #8)
     /** True if any tracker is logged in; gates the toolbar action (sheet vs Settings > Tracking). */
     fun hasLoggedInTrackers(): Boolean = trackerManager.loggedInTrackers().isNotEmpty()
 
@@ -959,7 +958,6 @@ class NovelDetailsScreenModel(
             }
         }
     }
-    // RK <--
 
     /** Row swipe, dispatched by the configured [LibraryPreferences.ChapterSwipeAction] (mirrors the
      *  manga path's `executeChapterSwipeAction`, with the same download-state to action mapping). */
@@ -1124,6 +1122,6 @@ sealed interface NovelDetailsDialog {
     data object FullCover : NovelDetailsDialog
     data class ManageSources(val sources: List<NovelMergeSourceInfo>) : NovelDetailsDialog
 
-    // RK: novel trackers (Active #8). Rendered as a NavigatorAdaptiveSheet, mirroring Mihon's manga sheet.
+    // novel trackers (Active #8). Rendered as a NavigatorAdaptiveSheet, mirroring Mihon's manga sheet.
     data object TrackSheet : NovelDetailsDialog
 }

--- a/app/src/main/java/reikai/presentation/novel/details/NovelScreen.kt
+++ b/app/src/main/java/reikai/presentation/novel/details/NovelScreen.kt
@@ -119,14 +119,14 @@ class NovelScreen(
                     }
                 }
                 val onSearch: (String) -> Unit = { query -> navigator.push(NovelGlobalSearchScreen(query)) }
-                // RK: migration only re-homes a library novel, so the action shows only when favorited.
+                // migration only re-homes a library novel, so the action shows only when favorited.
                 val onMigrate: (() -> Unit)? = if (s.novel.favorite) {
                     // displayNovel = the source you're viewing, so the picker pre-checks it for a merge.
                     { navigator.push(NovelMigrationSourcePickScreen(listOf(s.displayNovel.id))) }
                 } else {
                     null
                 }
-                // RK: tracking action; mirrors MangaScreen (no logged-in trackers -> Settings > Tracking).
+                // tracking action; mirrors MangaScreen (no logged-in trackers -> Settings > Tracking).
                 val onTracking: () -> Unit = {
                     if (screenModel.hasLoggedInTrackers()) {
                         screenModel.showTrackDialog()
@@ -134,7 +134,7 @@ class NovelScreen(
                         navigator.push(SettingsScreen(SettingsScreen.Destination.Tracking))
                     }
                 }
-                // RK: open the full-screen notes editor for the favorited (anchor) novel.
+                // open the full-screen notes editor for the favorited (anchor) novel.
                 val onEditNotes: () -> Unit = {
                     navigator.push(NovelNotesScreen(s.novel.id, s.novel.title, s.novel.notes))
                 }
@@ -426,7 +426,7 @@ private fun NovelDetailsDialogs(state: NovelDetailsState.Loaded, screenModel: No
             onRemoveFromLibrary = screenModel::removeSourcesFromLibrary,
             onRemoveAll = screenModel::removeAllSourcesFromLibrary,
         )
-        // RK: tracking sheet (Active #8). Remember by novel id so the merge collectors' frequent
+        // tracking sheet (Active #8). Remember by novel id so the merge collectors' frequent
         // recompositions don't rebuild it and reset its navigator mid-write (the manga side hit an
         // InsertTrack JobCancellationException here).
         NovelDetailsDialog.TrackSheet -> {
@@ -502,7 +502,7 @@ private fun LazyListScope.novelInfoItems(
             isTabletUi = isTabletUi,
             appBarPadding = appBarPadding,
             novel = display,
-            // RK: a merged group viewed via the "All" chip shows the unified label, mirroring the
+            // a merged group viewed via the "All" chip shows the unified label, mirroring the
             // manga header. A specific source chip keeps that source's resolved name.
             sourceName = if (state.mergeSources.size > 1 && state.selectedSourceNovelId == null) {
                 stringResource(MR.strings.merge_unified)
@@ -530,7 +530,7 @@ private fun LazyListScope.novelInfoItems(
             defaultExpandState = false,
             description = display.description,
             tagsProvider = { display.genre },
-            // RK: notes are a user annotation on the favorited anchor row, not the viewed source's metadata.
+            // notes are a user annotation on the favorited anchor row, not the viewed source's metadata.
             notes = state.novel.notes,
             onTagSearch = onSearch,
             onCopyTagToClipboard = { onCopy(it) },

--- a/app/src/main/java/reikai/presentation/novel/details/NovelToolbar.kt
+++ b/app/src/main/java/reikai/presentation/novel/details/NovelToolbar.kt
@@ -46,7 +46,7 @@ fun NovelToolbar(
     onClickEditNotes: () -> Unit,
     onClickShare: (() -> Unit)?,
     onClickManageSources: (() -> Unit)?,
-    // RK: null unless the novel is favorited (migration only re-homes a library novel).
+    // null unless the novel is favorited (migration only re-homes a library novel).
     onClickMigrate: (() -> Unit)?,
     onClickDownload: ((DownloadAction) -> Unit)?,
     actionModeCounter: Int,

--- a/app/src/main/java/reikai/presentation/novel/globalsearch/NovelGlobalSearchScreen.kt
+++ b/app/src/main/java/reikai/presentation/novel/globalsearch/NovelGlobalSearchScreen.kt
@@ -227,7 +227,7 @@ internal fun SourceSection(
     favoritedKeys: Set<Pair<String, String>>,
     onResultClick: (NovelItem) -> Unit,
     onResultLongClick: (NovelItem) -> Unit,
-    // RK: null in migrate mode, where opening the source's browse would be a dead-end.
+    // null in migrate mode, where opening the source's browse would be a dead-end.
     onClickSource: (() -> Unit)?,
 ) {
     val context = LocalContext.current

--- a/app/src/main/java/reikai/presentation/novel/reader/NovelReaderScreenModel.kt
+++ b/app/src/main/java/reikai/presentation/novel/reader/NovelReaderScreenModel.kt
@@ -86,10 +86,9 @@ class NovelReaderScreenModel(
     private val getNovelCategories: GetNovelCategories by injectLazy()
     private val deleteNovelChaptersAfterRead: DeleteNovelChaptersAfterRead by injectLazy()
 
-    // RK --> novel trackers (Active #8): push read progress on chapter completion
+    // novel trackers (Active #8): push read progress on chapter completion
     private val trackNovelChapter: TrackNovelChapter by injectLazy()
     private val trackPreferences: TrackPreferences by injectLazy()
-    // RK <--
 
     private val getIncognitoState: GetIncognitoState by injectLazy()
 
@@ -351,16 +350,15 @@ class NovelReaderScreenModel(
         mutableState.value = NovelReaderState.Loading
         screenModelScope.launchIO {
             updateHistory()
-            // RK --> mark-read-on-skip: the departed chapter + its owning novel are still current here
+            // mark-read-on-skip: the departed chapter + its owning novel are still current here
             // (before the reassignment + loadCurrent below re-point them to the incoming chapter).
             if (markDepartedRead) markReadOnSkip(currentId, currentNovelId)
-            // RK <--
             currentId = id
             loadCurrent()
         }
     }
 
-    // RK --> mark-read-on-skip (opt-in): mark the chapter the user skipped away from as read (forward
+    // mark-read-on-skip (opt-in): mark the chapter the user skipped away from as read (forward
     // only), the novel twin of ReaderViewModel.markChapterReadOnSkip. Reuses saveProgress's tracker push.
     private suspend fun markReadOnSkip(departedId: Long, departedNovelId: Long) {
         if (incognitoMode || !novelPreferences.readerMarkReadOnSkip().get()) return
@@ -371,7 +369,6 @@ class NovelReaderScreenModel(
             trackNovelChapter.await(Injekt.get<Application>(), departedNovelId, chapter.chapterNumber)
         }
     }
-    // RK <--
 
     /** Stamp the current chapter into novel history and accumulate this session's read time. Called on
      *  chapter switch and on leaving the reader (the novel twin of ReaderViewModel.updateHistory). */
@@ -509,11 +506,10 @@ class NovelReaderScreenModel(
             if (clamped >= 97) {
                 chapterRepo.setReadBulk(listOf(id), true)
                 val chapter = chapterRepo.getById(id)
-                // RK --> push read progress to bound trackers, mirroring ReaderViewModel.updateTrackChapterRead (Active #8)
+                // push read progress to bound trackers, mirroring ReaderViewModel.updateTrackChapterRead (Active #8)
                 if (trackPreferences.autoUpdateTrack.get()) {
                     chapter?.let { trackNovelChapter.await(Injekt.get<Application>(), currentNovelId, it.chapterNumber) }
                 }
-                // RK <--
                 // The in-RAM htmlCache keeps the current view alive, so deleting the file is safe here.
                 // Finishing a chapter marks it read, so honor "delete after marked as read" too.
                 chapter?.let { deleteNovelChaptersAfterRead.await(currentNovelId, listOf(it)) }

--- a/app/src/main/java/reikai/presentation/updates/ReikaiUpdatesCategoryFilter.kt
+++ b/app/src/main/java/reikai/presentation/updates/ReikaiUpdatesCategoryFilter.kt
@@ -82,7 +82,7 @@ fun ColumnScope.ReikaiUpdatesCategoryFilter(
     )
 }
 
-/** "Group by series" switch for the Updates filter dialog (a // RK addition, like the category row). */
+/** "Group by series" switch for the Updates filter dialog (a Reikai addition, like the category row). */
 @Composable
 fun ColumnScope.ReikaiUpdatesGroupToggle(screenModel: UpdatesSettingsScreenModel) {
     val grouped by screenModel.reikaiSourcePreferences.updatesGroupBySeries.collectAsPrefState()

--- a/app/src/test/java/reikai/domain/manga/MangaMergeManagerTest.kt
+++ b/app/src/test/java/reikai/domain/manga/MangaMergeManagerTest.kt
@@ -4,12 +4,15 @@ import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import reikai.domain.library.ReikaiLibraryPreferences
 import tachiyomi.core.common.preference.Preference
+import tachiyomi.domain.manga.interactor.GetFavorites
 import tachiyomi.domain.manga.model.Manga
 
 class MangaMergeManagerTest {
@@ -156,5 +159,45 @@ class MangaMergeManagerTest {
         result.newMerges shouldContainExactly setOf("1,2")
         // The suspect is unmerged from every survivor so it can't regroup with either.
         result.newUnmerges shouldContainExactlyInAnyOrder setOf("1,3", "2,3")
+    }
+
+    @Test
+    fun `mergeSelectedManga expands same-title cards so one merge coalesces every source`() = runTest {
+        val mergesPref = mockk<Preference<Set<String>>>(relaxed = true)
+        val unmergesPref = mockk<Preference<Set<String>>>(relaxed = true)
+        every { mergesPref.get() } returns emptySet()
+        every { unmergesPref.get() } returns emptySet()
+        val preferences = mockk<ReikaiLibraryPreferences> {
+            every { mangaManualMerges } returns mergesPref
+            every { mangaManualUnmerges } returns unmergesPref
+            every { autoMergeSameTitle } returns mockk(relaxed = true) { every { get() } returns true }
+        }
+        val getFavorites = mockk<GetFavorites>()
+        coEvery { getFavorites.await() } returns listOf(manga(1, "A"), manga(2, "A"), manga(3, "B"), manga(4, "B"))
+        val manager = MangaMergeManager(preferences, getFavorites, mockk())
+
+        // Select only the two collapsed cards' representatives (1 = card "A", 3 = card "B").
+        manager.mergeSelectedManga(listOf(1L, 3L))
+
+        // Both hidden same-title members (2, 4) are pulled in, so one merge records all four.
+        verify { mergesPref.set(setOf("1,2,3,4")) }
+    }
+
+    @Test
+    fun `mergeSelectedManga with auto-merge off merges only the selected ids`() = runTest {
+        val mergesPref = mockk<Preference<Set<String>>>(relaxed = true)
+        val unmergesPref = mockk<Preference<Set<String>>>(relaxed = true)
+        every { mergesPref.get() } returns emptySet()
+        every { unmergesPref.get() } returns emptySet()
+        val preferences = mockk<ReikaiLibraryPreferences> {
+            every { mangaManualMerges } returns mergesPref
+            every { mangaManualUnmerges } returns unmergesPref
+            every { autoMergeSameTitle } returns mockk(relaxed = true) { every { get() } returns false }
+        }
+        val manager = MangaMergeManager(preferences, mockk(), mockk())
+
+        manager.mergeSelectedManga(listOf(1L, 3L))
+
+        verify { mergesPref.set(setOf("1,3")) }
     }
 }

--- a/app/src/test/java/reikai/domain/novel/NovelMergeManagerTest.kt
+++ b/app/src/test/java/reikai/domain/novel/NovelMergeManagerTest.kt
@@ -5,6 +5,7 @@ import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import reikai.domain.library.ReikaiLibraryPreferences
@@ -99,5 +100,29 @@ class NovelMergeManagerTest {
         val favs = listOf(novel(1, "A", "X"), novel(2, "B", "Y"))
         val keys = manager(favs).seriesGroupKeys(favs)
         (keys[1L] == keys[2L]) shouldBe false
+    }
+
+    @Test
+    fun `mergeSelectedNovels expands same-title cards so one merge coalesces every source`() = runTest {
+        val mergesPref = mockk<Preference<Set<String>>>(relaxed = true)
+        val unmergesPref = mockk<Preference<Set<String>>>(relaxed = true)
+        every { mergesPref.get() } returns emptySet()
+        every { unmergesPref.get() } returns emptySet()
+        val preferences = mockk<ReikaiLibraryPreferences> {
+            every { novelManualMerges } returns mergesPref
+            every { novelManualUnmerges } returns unmergesPref
+            every { novelAutoMergeSameTitle } returns pref(true)
+            every { novelAutoMergeRequireAuthor } returns pref(true)
+        }
+        val repo = mockk<NovelRepository>()
+        coEvery { repo.getFavorites() } returns
+            listOf(novel(1, "A", "X"), novel(2, "A", "X"), novel(3, "B", "Y"), novel(4, "B", "Y"))
+        val manager = NovelMergeManager(preferences, repo)
+
+        // Select only the two collapsed cards' representatives (1 = card "A/X", 3 = card "B/Y").
+        manager.mergeSelectedNovels(listOf(1L, 3L))
+
+        // Both hidden same-title/author members (2, 4) are pulled in, so one merge records all four.
+        verify { mergesPref.set(setOf("1,2,3,4")) }
     }
 }


### PR DESCRIPTION
## What

Merging a series' copies from different sources now fully coalesces in a single tap, on both the manga and novel libraries.

## Why

The library shows one collapsed card per group, so a selection only carried each card's representative id. Merging representatives recorded just those ids and stranded their hidden same-title members, which then split into their own cards and had to be merged again. Worst right after a backup restore, which recreates many same-title auto-groups.

## How

- Merge now expands each selected card to its full resolved group (manual-merge members plus same-title favorites, minus existing unmerges) before recording, mirroring what unmerge already did.
- New expanding entry points (`mergeSelectedManga` / `mergeSelectedNovels`) for the library selection; migration keeps the unexpanded `mergeManga` / `mergeNovels`, so its behavior is unchanged.

Also includes a cleanup commit dropping stray `// RK` markers from net-new `reikai.*` / `exh.*` files (the marker convention is only for patches inside Mihon's own files).

## Verified

On-device with a restored backup: one tap coalesces every source. Unit tests cover the same-title expansion on both the manga and novel sides.

## Release

Cuts `0.1.5` (versionCode 175).
