### PR TITLE
chore(ci): build and preview only on app-affecting path changes

### DIFF
--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -7,15 +7,28 @@ concurrency:
 on:
   push:
     branches: [main]
-    paths-ignore:
-      - '**.md'
-      - '.github/**'
-      - '.claude/**'
-      - 'docs/**'
+    # Allow-list of app-affecting inputs (see preview.yml): only these can change the built APK,
+    # so only these run the build/test. Repo-only content (docs, .github, .githooks, .claude) is
+    # skipped, and new non-app content is excluded by default.
+    paths:
+      - '**/src/**'
+      - '**.kts'
+      - '**.pro'
+      - 'gradle/**'
+      - 'gradle.properties'
+      - 'gradlew'
+      - 'gradlew.bat'
   pull_request:
     paths:
-      - '**'
-      - '!**.md'
+      - '**/src/**'
+      - '**.kts'
+      - '**.pro'
+      - 'gradle/**'
+      - 'gradle.properties'
+      - 'gradlew'
+      - 'gradlew.bat'
+      # Per-locale translations compile fine on their own, so they don't need a build; only the
+      # base strings/plurals do.
       - '!i18n/src/commonMain/moko-resources/**/strings.xml'
       - '!i18n/src/commonMain/moko-resources/**/plurals.xml'
       - 'i18n/src/commonMain/moko-resources/base/strings.xml'

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -9,13 +9,18 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      # Non-app changes that never affect the built APK: docs, this/other CI workflows, and Claude
-      # tooling. A push is skipped only when every changed file matches (a mixed app+docs push builds).
-      - '**.md'
-      - '.github/**'
-      - '.claude/**'
-      - 'docs/**'
+    paths:
+      # Allow-list of app-affecting inputs: only a change to one of these can alter the built APK,
+      # so only these trigger a preview. Anything else (docs, .github, .githooks, .claude, repo
+      # meta) is repo-only and skipped. Whitelisting means new non-app content is excluded by
+      # default, and a new module / gradle file is covered automatically.
+      - '**/src/**'        # all module sources: Kotlin/Java, AndroidManifest, res, sqldelight, moko-resources
+      - '**.kts'           # gradle build scripts (root, modules, build-logic)
+      - '**.pro'           # proguard / R8 rules
+      - 'gradle/**'        # version catalogs, build-logic, wrapper
+      - 'gradle.properties'
+      - 'gradlew'
+      - 'gradlew.bat'
   workflow_dispatch:
     inputs:
       dry-run:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Reikai uses its own [Semantic Versioning](https://semver.org/) from the Mihon-ba
 
 ## [Unreleased]
 
+### Other
+
+- Build the app and publish previews only when an app-affecting file changes; docs and other repo-only updates no longer trigger a build.
+
 ## [0.1.5]
 
 ### Fixes


### PR DESCRIPTION
## What

A repo-only merge still triggered the preview publish and the build/test run (the merge that prompted this carried a `.githooks/` file, which the old ignore-list didn't cover), cutting a new preview version for changes that don't alter the app.

Switches both the **push** triggers (preview + build/test) and the build/test **PR** trigger from an ignore-list to an **allow-list** of app-affecting paths, so anything not listed is skipped by default:

- `**/src/**` (all module sources, manifests, resources, sqldelight, moko-resources), `**.kts` (gradle scripts), `**.pro` (R8 rules), `gradle/**` (version catalogs, build-logic, wrapper), `gradle.properties`, `gradlew`, `gradlew.bat`.
- Repo-only content (docs, `.github`, `.githooks`, `.claude`, repo meta) no longer triggers a build, and any new non-app content is excluded automatically; a new module or gradle file is covered without editing the list.
- The per-locale translations exemption on the build/test PR run is preserved (only base strings/plurals build).

CI config only; no app code changes.