### PR TITLE
fix(backup): stream backups so large libraries stop failing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ Reikai uses its own [Semantic Versioning](https://semver.org/) from the Mihon-ba
 
 ## [Unreleased]
 
+## [0.3.1]
+
+### Additions
+
+- **Create backup now lets you pick Manga, Novels, and Custom entry info separately.** Back up just one content type (which also makes the file smaller), or leave the custom title/cover edits out.
+
+### Fixes
+
+- **Backing up a large library with chapters enabled works again instead of leaving an empty file.** Restoring one no longer runs out of memory either, and a backup that does fail now reports the error instead of quietly stopping.
+
 ## [0.3.0]
 
 ### Additions

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -39,8 +39,8 @@ android {
         // versionCode must keep climbing and stay above the last Yokai-based build (168) so installs upgrade in place.
         applicationId = "eu.kanade.tachiyomi"
 
-        versionCode = 183
-        versionName = "0.3.0"
+        versionCode = 184
+        versionName = "0.3.1"
         // RK <--
 
         buildConfigField("String", "COMMIT_COUNT", "\"${getLatestCommitCount()}\"")

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/data/RestoreBackupScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/data/RestoreBackupScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.text.withStyle
 import androidx.core.net.toUri
 import cafe.adriel.voyager.core.model.StateScreenModel
 import cafe.adriel.voyager.core.model.rememberScreenModel
+import cafe.adriel.voyager.core.model.screenModelScope
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import eu.kanade.presentation.components.AppBar
@@ -32,6 +33,7 @@ import eu.kanade.tachiyomi.data.backup.restore.BackupRestoreJob
 import eu.kanade.tachiyomi.data.backup.restore.RestoreOptions
 import eu.kanade.tachiyomi.util.system.DeviceUtil
 import kotlinx.coroutines.flow.update
+import tachiyomi.core.common.util.lang.launchIO
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.components.LabeledCheckbox
 import tachiyomi.presentation.core.components.LazyColumnWithAction
@@ -170,7 +172,10 @@ private class RestoreBackupScreenModel(
 ) : StateScreenModel<RestoreBackupScreenModel.State>(State()) {
 
     init {
-        validate(uri.toUri())
+        // RK: validate now streams the file (suspend), so run it off the main thread.
+        screenModelScope.launchIO {
+            validate(uri.toUri())
+        }
     }
 
     fun toggle(setter: (RestoreOptions, Boolean) -> RestoreOptions, enabled: Boolean) {
@@ -189,7 +194,7 @@ private class RestoreBackupScreenModel(
         )
     }
 
-    private fun validate(uri: Uri) {
+    private suspend fun validate(uri: Uri) {
         val results = try {
             BackupFileValidator(context).validate(uri)
         } catch (e: Exception) {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/BackupFileValidator.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/BackupFileValidator.kt
@@ -2,7 +2,11 @@ package eu.kanade.tachiyomi.data.backup
 
 import android.content.Context
 import android.net.Uri
+import eu.kanade.tachiyomi.data.backup.models.BackupManga
+import eu.kanade.tachiyomi.data.backup.models.BackupNovel
+import eu.kanade.tachiyomi.data.backup.models.BackupSource
 import eu.kanade.tachiyomi.data.track.TrackerManager
+import kotlinx.serialization.protobuf.ProtoBuf
 import reikai.novel.source.NovelSourceManager
 import tachiyomi.domain.source.service.SourceManager
 import uy.kohesive.injekt.Injekt
@@ -15,21 +19,41 @@ class BackupFileValidator(
     private val trackerManager: TrackerManager = Injekt.get(),
     // RK: novels validate against their own source registry + the shared tracker manager.
     private val novelSourceManager: NovelSourceManager = Injekt.get(),
+    private val parser: ProtoBuf = Injekt.get(),
 ) {
 
     /**
      * Checks for critical backup file data.
      *
+     * RK: streams the backup field by field (via [BackupProtoReader]) and decodes only the manga,
+     * source, and novel entries it needs, instead of re-inflating the whole file, which OOMs on a
+     * large backup (Issue #53).
+     *
      * @return List of missing sources or missing trackers.
      */
-    fun validate(uri: Uri): Results {
-        val backup = try {
-            BackupDecoder(context).decode(uri)
+    suspend fun validate(uri: Uri): Results {
+        val backupSources = mutableListOf<BackupSource>()
+        val mangaTrackerIds = mutableSetOf<Int>()
+        val novelSources = mutableSetOf<String>()
+        val novelTrackerIds = mutableSetOf<Long>()
+
+        try {
+            BackupProtoReader(context).read(uri) { fieldNumber, data ->
+                when (fieldNumber) {
+                    1 -> parser.decodeFromByteArray(BackupManga.serializer(), data)
+                        .tracking.forEach { mangaTrackerIds.add(it.syncId) }
+                    101 -> backupSources.add(parser.decodeFromByteArray(BackupSource.serializer(), data))
+                    700 -> parser.decodeFromByteArray(BackupNovel.serializer(), data).let { novel ->
+                        novelSources.add(novel.source)
+                        novel.tracking.forEach { novelTrackerIds.add(it.trackerId) }
+                    }
+                }
+            }
         } catch (e: Exception) {
             throw IllegalStateException(e)
         }
 
-        val sources = backup.backupSources.associate { it.sourceId to it.name }
+        val sources = backupSources.associate { it.sourceId to it.name }
         val missingSources = sources
             .filter { sourceManager.get(it.key) == null }
             .values.map {
@@ -43,11 +67,7 @@ class BackupFileValidator(
             .distinct()
             .sorted()
 
-        val trackers = backup.backupManga
-            .flatMap { it.tracking }
-            .map { it.syncId }
-            .distinct()
-        val missingTrackers = trackers
+        val missingTrackers = mangaTrackerIds
             .mapNotNull { trackerManager.get(it.toLong()) }
             .filter { !it.isLoggedIn }
             .map { it.name }
@@ -56,14 +76,9 @@ class BackupFileValidator(
         // RK --> fold in novel sources / trackers the restore can't satisfy, so the pre-restore
         // warning covers novels too. A missing novel source shows by its id (novels carry no
         // source-name table); novel trackers reuse the shared tracker manager.
-        val missingNovelSources = backup.backupNovels
-            .map { it.source }
-            .distinct()
+        val missingNovelSources = novelSources
             .filter { novelSourceManager.get(it) == null }
-        val missingNovelTrackers = backup.backupNovels
-            .flatMap { it.tracking }
-            .map { it.trackerId }
-            .distinct()
+        val missingNovelTrackers = novelTrackerIds
             .mapNotNull { trackerManager.get(it) }
             .filter { !it.isLoggedIn }
             .map { it.name }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/BackupProtoReader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/BackupProtoReader.kt
@@ -1,0 +1,97 @@
+// RK: net-new. Streams a backup's top-level protobuf fields one at a time so a large backup is
+// never fully materialised in memory (the read counterpart to BackupCreator.writeProtoField). Used
+// by BackupFileValidator and BackupRestorer to replace the whole-file decodeFromByteArray, which
+// OOMs on large libraries. Generic proto framing, no content-type coupling.
+package eu.kanade.tachiyomi.data.backup
+
+import android.content.Context
+import android.net.Uri
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okio.buffer
+import okio.gzip
+import okio.source
+import tachiyomi.core.common.i18n.stringResource
+import tachiyomi.i18n.MR
+import java.io.IOException
+
+class BackupProtoReader(
+    private val context: Context,
+) {
+    /**
+     * Reads the gzipped backup at [uri] field by field, invoking [onField] with each top-level
+     * field's number and its length-delimited bytes. Non-length-delimited fields are skipped.
+     */
+    suspend fun read(uri: Uri, onField: suspend (fieldNumber: Int, data: ByteArray) -> Unit) {
+        withContext(Dispatchers.IO) {
+            context.contentResolver.openInputStream(uri)!!.use { inputStream ->
+                val source = inputStream.source().buffer()
+
+                val peeked = source.peek().apply {
+                    require(2)
+                }
+                val id1id2 = peeked.readShort().toInt()
+
+                val payloadSource = when (id1id2) {
+                    GZIP_MAGIC -> source.gzip().buffer()
+                    MAGIC_JSON_SIGNATURE1, MAGIC_JSON_SIGNATURE2, MAGIC_JSON_SIGNATURE3 -> {
+                        throw IOException(context.stringResource(MR.strings.invalid_backup_file_json))
+                    }
+                    else -> source
+                }
+
+                while (true) {
+                    val tag = readVarint(payloadSource) ?: break
+                    val wireType = (tag and 0x07).toInt()
+                    val fieldNumber = (tag ushr 3).toInt()
+
+                    when (wireType) {
+                        WIRE_TYPE_LENGTH_DELIMITED -> {
+                            val length = readVarint(payloadSource)
+                                ?: throw IOException(context.stringResource(MR.strings.invalid_backup_file_unknown))
+                            if (length > Int.MAX_VALUE) {
+                                throw IOException(context.stringResource(MR.strings.invalid_backup_file_unknown))
+                            }
+                            val bytes = payloadSource.readByteArray(length)
+                            onField(fieldNumber, bytes)
+                        }
+                        WIRE_TYPE_VARINT -> {
+                            readVarint(payloadSource)
+                                ?: throw IOException(context.stringResource(MR.strings.invalid_backup_file_unknown))
+                        }
+                        WIRE_TYPE_64BIT -> payloadSource.skip(8)
+                        WIRE_TYPE_32BIT -> payloadSource.skip(4)
+                        else -> throw IOException(context.stringResource(MR.strings.invalid_backup_file_unknown))
+                    }
+                }
+            }
+        }
+    }
+
+    private fun readVarint(source: okio.BufferedSource): Long? {
+        if (source.exhausted()) return null
+
+        var shift = 0
+        var result = 0L
+        while (shift < 64) {
+            val b = source.readByte().toInt() and 0xff
+            result = result or ((b and 0x7f).toLong() shl shift)
+            if (b and 0x80 == 0) {
+                return result
+            }
+            shift += 7
+        }
+        throw IOException(context.stringResource(MR.strings.invalid_backup_file_unknown))
+    }
+
+    companion object {
+        private const val WIRE_TYPE_VARINT = 0
+        private const val WIRE_TYPE_64BIT = 1
+        private const val WIRE_TYPE_LENGTH_DELIMITED = 2
+        private const val WIRE_TYPE_32BIT = 5
+        private const val GZIP_MAGIC = 0x1f8b
+        private const val MAGIC_JSON_SIGNATURE1 = 0x7b7d // "{}"
+        private const val MAGIC_JSON_SIGNATURE2 = 0x7b22 // "{\""
+        private const val MAGIC_JSON_SIGNATURE3 = 0x7b0a // "{\n"
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/create/BackupCreateJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/create/BackupCreateJob.kt
@@ -56,7 +56,9 @@ class BackupCreateJob(private val context: Context, workerParams: WorkerParamete
                 notifier.showBackupComplete(UniFile.fromUri(context, location.toUri())!!)
             }
             Result.success()
-        } catch (e: Exception) {
+        } catch (e: Throwable) {
+            // Throwable, not Exception: an out-of-memory backup fails with an Error, which the old
+            // Exception-only catch skipped, so the job died silently with no error shown (Issue #53).
             logcat(LogPriority.ERROR, e)
             if (!isAutoBackup) notifier.showBackupError(e.message)
             Result.failure()

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/create/BackupCreator.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/create/BackupCreator.kt
@@ -12,17 +12,22 @@ import eu.kanade.tachiyomi.data.backup.create.creators.MangaBackupCreator
 import eu.kanade.tachiyomi.data.backup.create.creators.NovelBackupCreator
 import eu.kanade.tachiyomi.data.backup.create.creators.PreferenceBackupCreator
 import eu.kanade.tachiyomi.data.backup.create.creators.SourcesBackupCreator
-import eu.kanade.tachiyomi.data.backup.models.Backup
 import eu.kanade.tachiyomi.data.backup.models.BackupCategory
 import eu.kanade.tachiyomi.data.backup.models.BackupCustomMangaInfo
+import eu.kanade.tachiyomi.data.backup.models.BackupCustomNovelInfo
 import eu.kanade.tachiyomi.data.backup.models.BackupExtension
 import eu.kanade.tachiyomi.data.backup.models.BackupExtensionStore
 import eu.kanade.tachiyomi.data.backup.models.BackupManga
 import eu.kanade.tachiyomi.data.backup.models.BackupMangaMergeGroup
 import eu.kanade.tachiyomi.data.backup.models.BackupMangaSourceRef
+import eu.kanade.tachiyomi.data.backup.models.BackupNovel
+import eu.kanade.tachiyomi.data.backup.models.BackupNovelCategory
+import eu.kanade.tachiyomi.data.backup.models.BackupNovelMergeGroup
 import eu.kanade.tachiyomi.data.backup.models.BackupPreference
 import eu.kanade.tachiyomi.data.backup.models.BackupSource
 import eu.kanade.tachiyomi.data.backup.models.BackupSourcePreferences
+import kotlinx.coroutines.yield
+import kotlinx.serialization.SerializationStrategy
 import kotlinx.serialization.protobuf.ProtoBuf
 import logcat.LogPriority
 import okio.buffer
@@ -40,6 +45,7 @@ import tachiyomi.i18n.MR
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 import java.io.FileOutputStream
+import java.io.OutputStream
 import java.text.SimpleDateFormat
 import java.time.Instant
 import java.util.Date
@@ -69,6 +75,16 @@ class BackupCreator(
     // RK <--
 ) {
 
+    // RK: set once any field is written, so a selection that produces no content (e.g. Library
+    // entries on but Manga + Novels + everything else off) is rejected instead of writing a useless
+    // near-empty file, matching the old empty_backup_error guard the one-shot encode had.
+    private var wroteAnything = false
+
+    // RK: the backup is streamed field by field straight to the gzip sink instead of building the
+    // whole Backup object graph and encoding it in one ByteArray. The one-shot encode peaked at
+    // (object graph + a ~2x transient copy) and OutOfMemoryError'd on large chapter counts
+    // (Issue #53). A protobuf message is just its length-delimited fields concatenated in any order,
+    // so per-field streaming is wire-identical: old backups still decode, new ones stay in-format.
     suspend fun backup(uri: Uri, options: BackupOptions): String {
         var file: UniFile? = null
         try {
@@ -93,57 +109,117 @@ class BackupCreator(
                 throw IllegalStateException(context.stringResource(MR.strings.create_backup_file_error))
             }
 
-            val favorites = getFavorites.await()
-            val nonFavoriteManga = if (options.readEntries) mangaRepository.getReadMangaNotInLibrary() else emptyList()
-            val backupManga = backupMangas(favorites + nonFavoriteManga, options)
+            // Favorites carry no chapters, so the metadata list is light even for a big library; the
+            // chapters (the OOM driver) are only ever resident one batch at a time via the stream.
+            val includeManga = options.libraryEntries && options.includeManga
+            val includeNovels = options.libraryEntries && options.includeNovels
+            val favorites = if (includeManga) getFavorites.await() else emptyList()
 
-            // RK: the light-novel library (favorites + chapters/categories/tracks/history + merges).
-            val novelData = novelBackupCreator(options)
+            val outputStream = file.openOutputStream()
+            // Force overwrite old file
+            (outputStream as? FileOutputStream)?.channel?.truncate(0)
+            val gzipOut = outputStream.sink().gzip().buffer()
 
-            val backup = Backup(
-                backupManga = backupManga,
-                backupCategories = backupCategories(options),
-                backupSources = backupSources(backupManga),
-                backupPreferences = backupAppPreferences(options),
-                backupExtensionStores = backupExtensionStores(options),
-                backupSourcePreferences = backupSourcePreferences(options),
+            try {
+                val out = gzipOut.outputStream()
+                val sourceIds = mutableSetOf<Long>()
+
+                // Field 1: manga, streamed. Each is encoded and written on its own, then collected.
+                if (includeManga) {
+                    val nonFavorite = if (options.readEntries) {
+                        mangaRepository.getReadMangaNotInLibrary()
+                    } else {
+                        emptyList()
+                    }
+                    (favorites + nonFavorite).chunked(MANGA_BATCH_SIZE).forEach { batch ->
+                        mangaBackupCreator.backupMangaStream(batch, options).collect { manga ->
+                            sourceIds.add(manga.source)
+                            BackupProtoWriter.writeField(
+                                out,
+                                1,
+                                parser.encodeToByteArray(BackupManga.serializer(), manga),
+                            )
+                            wroteAnything = true
+                        }
+                        // Push the batch's deflated bytes to disk so nothing accumulates across a big backup.
+                        gzipOut.flush()
+                        yield()
+                    }
+                }
+
+                // Field 700 (RK): novels, streamed the same way.
+                if (includeNovels) {
+                    var written = 0
+                    novelBackupCreator.streamNovels(options).collect { novel ->
+                        BackupProtoWriter.writeField(
+                            out,
+                            700,
+                            parser.encodeToByteArray(BackupNovel.serializer(), novel),
+                        )
+                        wroteAnything = true
+                        if (++written % MANGA_BATCH_SIZE == 0) {
+                            gzipOut.flush()
+                            yield()
+                        }
+                    }
+                    gzipOut.flush()
+                }
+
+                // Remaining fields are small (no per-entry chapter payload), so they are gathered and
+                // written after the streamed entries. Field order is irrelevant to the decoder.
+                writeEach(out, 2, BackupCategory.serializer(), backupCategories(options))
+                writeEach(out, 101, BackupSource.serializer(), sourcesBackupCreator.forSourceIds(sourceIds))
+                writeEach(out, 104, BackupPreference.serializer(), backupAppPreferences(options))
+                writeEach(out, 105, BackupSourcePreferences.serializer(), backupSourcePreferences(options))
+                writeEach(out, 106, BackupExtensionStore.serializer(), backupExtensionStores(options))
                 // RK -->
-                backupNovels = novelData.novels,
-                backupNovelCategories = novelData.categories,
-                backupNovelMerges = novelData.merges,
-                backupNovelUnmerges = novelData.unmerges,
-                backupExtensions = backupExtensions(options),
-                backupMangaMerges = backupMangaMergeGroups(
-                    reikaiLibraryPreferences.mangaManualMerges.get(),
-                    favorites,
-                    options,
-                ),
-                backupMangaUnmerges = backupMangaMergeGroups(
-                    reikaiLibraryPreferences.mangaManualUnmerges.get(),
-                    favorites,
-                    options,
-                ),
-                backupCustomMangaInfo = backupCustomMangaInfo(favorites, options),
-                backupCustomNovelInfo = novelData.customInfo,
+                writeEach(out, 710, BackupExtension.serializer(), backupExtensions(options))
+                if (includeManga) {
+                    val merges = reikaiLibraryPreferences.mangaManualMerges.get()
+                    val unmerges = reikaiLibraryPreferences.mangaManualUnmerges.get()
+                    writeEach(
+                        out,
+                        711,
+                        BackupMangaMergeGroup.serializer(),
+                        backupMangaMergeGroups(merges, favorites, options),
+                    )
+                    writeEach(
+                        out,
+                        712,
+                        BackupMangaMergeGroup.serializer(),
+                        backupMangaMergeGroups(unmerges, favorites, options),
+                    )
+                    if (options.customInfo) {
+                        writeEach(
+                            out,
+                            713,
+                            BackupCustomMangaInfo.serializer(),
+                            backupCustomMangaInfo(favorites, options),
+                        )
+                    }
+                }
+                if (includeNovels) {
+                    writeEach(out, 701, BackupNovelCategory.serializer(), novelBackupCreator.novelCategories(options))
+                    writeEach(out, 702, BackupNovelMergeGroup.serializer(), novelBackupCreator.novelMerges(options))
+                    writeEach(out, 703, BackupNovelMergeGroup.serializer(), novelBackupCreator.novelUnmerges(options))
+                    if (options.customInfo) {
+                        writeEach(out, 714, BackupCustomNovelInfo.serializer(), novelBackupCreator.novelCustomInfo())
+                    }
+                }
                 // RK <--
-            )
 
-            val byteArray = parser.encodeToByteArray(Backup.serializer(), backup)
-            if (byteArray.isEmpty()) {
+                gzipOut.flush()
+            } finally {
+                gzipOut.close()
+            }
+
+            if (!wroteAnything) {
                 throw IllegalStateException(context.stringResource(MR.strings.empty_backup_error))
             }
 
-            file.openOutputStream()
-                .also {
-                    // Force overwrite old file
-                    (it as? FileOutputStream)?.channel?.truncate(0)
-                }
-                .sink().gzip().buffer().use {
-                    it.write(byteArray)
-                }
             val fileUri = file.uri
 
-            // Make sure it's a valid backup file
+            // Make sure it's a valid backup file (streamed, so it doesn't re-inflate the whole file).
             BackupFileValidator(context).validate(fileUri)
 
             if (isAutoBackup) {
@@ -151,27 +227,34 @@ class BackupCreator(
             }
 
             return fileUri.toString()
-        } catch (e: Exception) {
+        } catch (e: Throwable) {
+            // Throwable, not Exception: an OutOfMemoryError is an Error, and catching only Exception
+            // left the blank half-written file behind and swallowed the failure (Issue #53).
             logcat(LogPriority.ERROR, e)
-            file?.delete()
+            try {
+                file?.delete()
+            } catch (deleteError: Exception) {
+                logcat(LogPriority.WARN, deleteError) { "Failed to delete partial backup file" }
+            }
             throw e
         }
+    }
+
+    /** Encode each item and write it as a repeated length-delimited field. */
+    private fun <T> writeEach(
+        out: OutputStream,
+        fieldNumber: Int,
+        serializer: SerializationStrategy<T>,
+        items: List<T>,
+    ) {
+        if (items.isNotEmpty()) wroteAnything = true
+        items.forEach { BackupProtoWriter.writeField(out, fieldNumber, parser.encodeToByteArray(serializer, it)) }
     }
 
     private suspend fun backupCategories(options: BackupOptions): List<BackupCategory> {
         if (!options.categories) return emptyList()
 
         return categoriesBackupCreator()
-    }
-
-    private suspend fun backupMangas(mangas: List<Manga>, options: BackupOptions): List<BackupManga> {
-        if (!options.libraryEntries) return emptyList()
-
-        return mangaBackupCreator(mangas, options)
-    }
-
-    private fun backupSources(mangas: List<BackupManga>): List<BackupSource> {
-        return sourcesBackupCreator(mangas)
     }
 
     private fun backupAppPreferences(options: BackupOptions): List<BackupPreference> {
@@ -245,6 +328,11 @@ class BackupCreator(
 
     companion object {
         private const val MAX_AUTO_BACKUPS: Int = 4
+
+        // RK: how many entries to stream before flushing the gzip buffer to disk, so buffered bytes
+        // don't pile up across a very large backup.
+        private const val MANGA_BATCH_SIZE: Int = 20
+
         private val FILENAME_REGEX = """${BuildConfig.APPLICATION_ID}_\d{4}-\d{2}-\d{2}_\d{2}-\d{2}.tachibk""".toRegex()
 
         fun getFilename(): String {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/create/BackupOptions.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/create/BackupOptions.kt
@@ -5,6 +5,10 @@ import tachiyomi.i18n.MR
 
 data class BackupOptions(
     val libraryEntries: Boolean = true,
+    // RK: per-content-type + custom-info filters, nested under libraryEntries in the create UI.
+    val includeManga: Boolean = true,
+    val includeNovels: Boolean = true,
+    val customInfo: Boolean = true,
     val categories: Boolean = true,
     val chapters: Boolean = true,
     val tracking: Boolean = true,
@@ -18,6 +22,9 @@ data class BackupOptions(
 
     fun asBooleanArray() = booleanArrayOf(
         libraryEntries,
+        includeManga,
+        includeNovels,
+        customInfo,
         categories,
         chapters,
         tracking,
@@ -37,6 +44,19 @@ data class BackupOptions(
                 label = MR.strings.manga,
                 getter = BackupOptions::libraryEntries,
                 setter = { options, enabled -> options.copy(libraryEntries = enabled) },
+            ),
+            // RK: content-type filters (back up manga-only / novels-only; also halves size).
+            Entry(
+                label = MR.strings.content_type_manga,
+                getter = BackupOptions::includeManga,
+                setter = { options, enabled -> options.copy(includeManga = enabled) },
+                enabled = { it.libraryEntries },
+            ),
+            Entry(
+                label = MR.strings.content_type_novels,
+                getter = BackupOptions::includeNovels,
+                setter = { options, enabled -> options.copy(includeNovels = enabled) },
+                enabled = { it.libraryEntries },
             ),
             Entry(
                 label = MR.strings.chapters,
@@ -67,6 +87,13 @@ data class BackupOptions(
                 setter = { options, enabled -> options.copy(readEntries = enabled) },
                 enabled = { it.libraryEntries },
             ),
+            // RK: exclude the non-destructive custom-info overlay independently.
+            Entry(
+                label = MR.strings.custom_entry_info,
+                getter = BackupOptions::customInfo,
+                setter = { options, enabled -> options.copy(customInfo = enabled) },
+                enabled = { it.libraryEntries },
+            ),
         )
 
         val settingsOptions = listOf(
@@ -95,15 +122,18 @@ data class BackupOptions(
 
         fun fromBooleanArray(array: BooleanArray) = BackupOptions(
             libraryEntries = array[0],
-            categories = array[1],
-            chapters = array[2],
-            tracking = array[3],
-            history = array[4],
-            readEntries = array[5],
-            appSettings = array[6],
-            extensionStores = array[7],
-            sourceSettings = array[8],
-            privateSettings = array[9],
+            includeManga = array[1],
+            includeNovels = array[2],
+            customInfo = array[3],
+            categories = array[4],
+            chapters = array[5],
+            tracking = array[6],
+            history = array[7],
+            readEntries = array[8],
+            appSettings = array[9],
+            extensionStores = array[10],
+            sourceSettings = array[11],
+            privateSettings = array[12],
         )
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/create/BackupProtoWriter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/create/BackupProtoWriter.kt
@@ -1,0 +1,28 @@
+// RK: net-new. Writes a single top-level protobuf field (write side of BackupProtoReader) so the
+// backup can be streamed field by field instead of encoding the whole Backup at once, which OOMs on
+// large libraries (Issue #53). Extracted from BackupCreator so the hand-rolled wire framing is unit
+// tested directly (a wrong field number or varint corrupts every backup).
+package eu.kanade.tachiyomi.data.backup.create
+
+import java.io.OutputStream
+
+internal object BackupProtoWriter {
+
+    /** Write [data] as the length-delimited (wire type 2) field [fieldNumber]. */
+    fun writeField(out: OutputStream, fieldNumber: Int, data: ByteArray) {
+        // Tag = (fieldNumber << 3) | 2 (length-delimited)
+        writeVarint(out, (fieldNumber.toLong() shl 3) or 2L)
+        writeVarint(out, data.size.toLong())
+        out.write(data)
+    }
+
+    /** Write [value] as a protobuf base-128 varint. */
+    private fun writeVarint(out: OutputStream, value: Long) {
+        var v = value
+        while (v and 0x7FL.inv() != 0L) {
+            out.write(((v and 0x7F) or 0x80).toInt())
+            v = v ushr 7
+        }
+        out.write((v and 0x7F).toInt())
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/create/creators/MangaBackupCreator.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/create/creators/MangaBackupCreator.kt
@@ -12,6 +12,9 @@ import eu.kanade.tachiyomi.data.backup.models.BackupSearchTitle
 import eu.kanade.tachiyomi.data.backup.models.backupChapterMapper
 import eu.kanade.tachiyomi.data.backup.models.backupTrackMapper
 import eu.kanade.tachiyomi.ui.reader.setting.ReadingMode
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.yield
 import tachiyomi.data.Database
 import tachiyomi.data.MemoColumnAdapter
 import tachiyomi.domain.category.interactor.GetCategories
@@ -32,6 +35,16 @@ class MangaBackupCreator(
     suspend operator fun invoke(mangas: List<Manga>, options: BackupOptions): List<BackupManga> {
         return mangas.map {
             backupManga(it, options)
+        }
+    }
+
+    // RK: emit one BackupManga at a time so the caller can encode + write each to the backup stream
+    // and let it be collected, instead of holding every manga (and all its chapters) in memory. This
+    // is what keeps a large-library backup from OOMing on the chapters payload.
+    fun backupMangaStream(mangas: List<Manga>, options: BackupOptions): Flow<BackupManga> = flow {
+        for (manga in mangas) {
+            emit(backupManga(manga, options))
+            yield()
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/create/creators/NovelBackupCreator.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/create/creators/NovelBackupCreator.kt
@@ -14,6 +14,9 @@ import eu.kanade.tachiyomi.data.backup.models.BackupNovelHistory
 import eu.kanade.tachiyomi.data.backup.models.BackupNovelMergeGroup
 import eu.kanade.tachiyomi.data.backup.models.BackupNovelSourceRef
 import eu.kanade.tachiyomi.data.backup.models.BackupNovelTracking
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.yield
 import reikai.domain.library.ReikaiLibraryPreferences
 import reikai.domain.novel.NovelCategoryRepository
 import reikai.domain.novel.NovelChapterRepository
@@ -37,39 +40,32 @@ class NovelBackupCreator(
     private val database: Database = Injekt.get(),
 ) {
 
-    data class NovelBackupData(
-        val novels: List<BackupNovel>,
-        val categories: List<BackupNovelCategory>,
-        val merges: List<BackupNovelMergeGroup>,
-        val unmerges: List<BackupNovelMergeGroup>,
-        val customInfo: List<BackupCustomNovelInfo>,
-    )
-
-    suspend operator fun invoke(options: BackupOptions): NovelBackupData {
-        val favorites = if (options.libraryEntries) novelRepository.getFavorites() else emptyList()
-        return NovelBackupData(
-            novels = if (options.libraryEntries) favorites.map { backupNovel(it, options) } else emptyList(),
-            categories = if (options.categories) backupNovelCategories() else emptyList(),
-            customInfo = if (options.libraryEntries) backupCustomNovelInfo(favorites) else emptyList(),
-            merges = if (options.libraryEntries) {
-                serializeGroups(preferences.novelManualMerges.get(), favorites)
-            } else {
-                emptyList()
-            },
-            unmerges = if (options.libraryEntries) {
-                serializeGroups(preferences.novelManualUnmerges.get(), favorites)
-            } else {
-                emptyList()
-            },
-        )
+    // Emit one BackupNovel at a time so the caller streams each straight to the backup, instead of
+    // materialising every novel and all its chapters at once (the novel twin of backupMangaStream).
+    fun streamNovels(options: BackupOptions): Flow<BackupNovel> = flow {
+        if (!options.libraryEntries) return@flow
+        for (novel in novelRepository.getFavorites()) {
+            emit(backupNovel(novel, options))
+            yield()
+        }
     }
 
+    suspend fun novelCategories(options: BackupOptions): List<BackupNovelCategory> =
+        if (options.categories) backupNovelCategories() else emptyList()
+
+    suspend fun novelMerges(options: BackupOptions): List<BackupNovelMergeGroup> =
+        if (options.libraryEntries) serializeGroups(preferences.novelManualMerges.get()) else emptyList()
+
+    suspend fun novelUnmerges(options: BackupOptions): List<BackupNovelMergeGroup> =
+        if (options.libraryEntries) serializeGroups(preferences.novelManualUnmerges.get()) else emptyList()
+
     // Back up the novel custom-info overlay as {url, source}-keyed entries (re-keyed to fresh ids on
-    // restore). The favorites map resolves each row's novel; a row for a non-favorite is dropped.
-    private suspend fun backupCustomNovelInfo(favorites: List<Novel>): List<BackupCustomNovelInfo> {
-        val byId = favorites.associateBy { it.id }
+    // restore). Resolves each row's novel by id (no favorites map needed, so it doesn't force the
+    // whole favorites list to stay resident during the streamed backup). A row whose novel is gone
+    // is dropped. The caller gates this on the include-novels + custom-info toggles.
+    suspend fun novelCustomInfo(): List<BackupCustomNovelInfo> {
         return customNovelInfoRepository.getAll().mapNotNull { info ->
-            val novel = byId[info.novelId] ?: return@mapNotNull null
+            val novel = novelRepository.getById(info.novelId) ?: return@mapNotNull null
             BackupCustomNovelInfo(
                 source = novel.source,
                 url = novel.url,
@@ -130,17 +126,17 @@ class NovelBackupCreator(
 
     /**
      * Translate the preference's comma-joined ID groups into {url, source} refs. A group is dropped
-     * if fewer than two of its members resolve (a one-member group is no longer a merge).
+     * if fewer than two of its members resolve (a one-member group is no longer a merge). Each member
+     * is looked up by id: the streamed backup never holds the favorites list, so there is no map to
+     * resolve against, and a merge pref holds few enough ids for that to be cheap.
      */
-    private suspend fun serializeGroups(groups: Set<String>, favorites: List<Novel>): List<BackupNovelMergeGroup> {
+    private suspend fun serializeGroups(groups: Set<String>): List<BackupNovelMergeGroup> {
         if (groups.isEmpty()) return emptyList()
-        val byId = favorites.associateBy { it.id }
         return groups.mapNotNull { group ->
             val refs = group.split(",")
                 .mapNotNull { it.trim().toLongOrNull() }
                 .mapNotNull { id ->
-                    val novel = byId[id] ?: novelRepository.getById(id)
-                    novel?.let { BackupNovelSourceRef(url = it.url, source = it.source) }
+                    novelRepository.getById(id)?.let { BackupNovelSourceRef(url = it.url, source = it.source) }
                 }
             refs.takeIf { it.size >= 2 }?.let { BackupNovelMergeGroup(refs = it) }
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/create/creators/SourcesBackupCreator.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/create/creators/SourcesBackupCreator.kt
@@ -20,6 +20,14 @@ class SourcesBackupCreator(
             .map { it.toBackupSource() }
             .toList()
     }
+
+    // RK: build the source list from ids collected during the streaming manga pass, so the whole
+    // List<BackupManga> never has to be resident just to derive sources.
+    fun forSourceIds(sourceIds: Set<Long>): List<BackupSource> {
+        return sourceIds
+            .map(sourceManager::getOrStub)
+            .map { it.toBackupSource() }
+    }
 }
 
 private fun Source.toBackupSource() =

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/BackupRestorer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/BackupRestorer.kt
@@ -2,14 +2,20 @@ package eu.kanade.tachiyomi.data.backup.restore
 
 import android.content.Context
 import android.net.Uri
-import eu.kanade.tachiyomi.data.backup.BackupDecoder
 import eu.kanade.tachiyomi.data.backup.BackupNotifier
-import eu.kanade.tachiyomi.data.backup.models.Backup
+import eu.kanade.tachiyomi.data.backup.BackupProtoReader
 import eu.kanade.tachiyomi.data.backup.models.BackupCategory
 import eu.kanade.tachiyomi.data.backup.models.BackupCustomMangaInfo
+import eu.kanade.tachiyomi.data.backup.models.BackupCustomNovelInfo
+import eu.kanade.tachiyomi.data.backup.models.BackupExtension
+import eu.kanade.tachiyomi.data.backup.models.BackupExtensionStore
 import eu.kanade.tachiyomi.data.backup.models.BackupManga
 import eu.kanade.tachiyomi.data.backup.models.BackupMangaMergeGroup
+import eu.kanade.tachiyomi.data.backup.models.BackupNovel
+import eu.kanade.tachiyomi.data.backup.models.BackupNovelCategory
+import eu.kanade.tachiyomi.data.backup.models.BackupNovelMergeGroup
 import eu.kanade.tachiyomi.data.backup.models.BackupPreference
+import eu.kanade.tachiyomi.data.backup.models.BackupSource
 import eu.kanade.tachiyomi.data.backup.models.BackupSourcePreferences
 import eu.kanade.tachiyomi.data.backup.restore.restorers.CategoriesRestorer
 import eu.kanade.tachiyomi.data.backup.restore.restorers.ExtensionRestorer
@@ -24,6 +30,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.launch
+import kotlinx.serialization.protobuf.ProtoBuf
 import logcat.LogPriority
 import tachiyomi.core.common.i18n.stringResource
 import tachiyomi.core.common.util.system.logcat
@@ -51,6 +58,7 @@ class BackupRestorer(
     private val preferenceRestorer: PreferenceRestorer = PreferenceRestorer(context),
     private val extensionStoreRestorer: ExtensionStoreRestorer = ExtensionStoreRestorer(),
     private val mangaRestorer: MangaRestorer = MangaRestorer(),
+    private val parser: ProtoBuf = Injekt.get(),
     // RK -->
     private val novelRestorer: NovelRestorer = NovelRestorer(),
     private val extensionRestorer: ExtensionRestorer = ExtensionRestorer(),
@@ -94,15 +102,18 @@ class BackupRestorer(
         )
     }
 
+    // RK: restore streams the backup instead of decoding the whole file into memory (which OOMs on a
+    // large library, the read side of Issue #53). Pass 1 (readBackupSummary) gathers the small fields
+    // and counts the library entries; the entries themselves are streamed and restored one bounded
+    // batch at a time in restoreMangaStream / restoreNovelsStream.
     private suspend fun restoreFromFile(uri: Uri, options: RestoreOptions) {
-        val backup = BackupDecoder(context).decode(uri)
+        val summary = readBackupSummary(uri)
 
         // Store source mapping for error messages
-        val backupMaps = backup.backupSources
-        sourceMapping = backupMaps.associate { it.sourceId to it.name }
+        sourceMapping = summary.backupSources.associate { it.sourceId to it.name }
 
         if (options.libraryEntries) {
-            restoreAmount += backup.backupManga.size
+            restoreAmount += summary.mangaCount + summary.novelCount
         }
         if (options.categories) {
             restoreAmount += 1
@@ -111,14 +122,10 @@ class BackupRestorer(
             restoreAmount += 1
         }
         if (options.extensionStores) {
-            restoreAmount += backup.backupExtensionStores.size
+            restoreAmount += summary.backupExtensionStores.size
         }
         if (options.sourceSettings) {
             restoreAmount += 1
-        }
-        // RK: count restored novels toward progress.
-        if (options.libraryEntries) {
-            restoreAmount += backup.backupNovels.size
         }
 
         coroutineScope {
@@ -129,28 +136,28 @@ class BackupRestorer(
             // Default category (a long-standing Tachiyomi-lineage race: a random count slips through each
             // run). Awaiting the categories job first fixes it; everything below stays parallel.
             if (options.categories) {
-                restoreCategories(backup.backupCategories).join()
+                restoreCategories(summary.backupCategories).join()
             }
             if (options.appSettings) {
-                restoreAppPreferences(backup.backupPreferences, backup.backupCategories.takeIf { options.categories })
+                restoreAppPreferences(summary.backupPreferences, summary.backupCategories.takeIf { options.categories })
             }
             if (options.sourceSettings) {
-                restoreSourcePreferences(backup.backupSourcePreferences)
+                restoreSourcePreferences(summary.backupSourcePreferences)
             }
             if (options.libraryEntries) {
-                restoreManga(
-                    backup.backupManga,
-                    if (options.categories) backup.backupCategories else emptyList(),
-                    backup.backupMangaMerges,
-                    backup.backupMangaUnmerges,
-                    backup.backupCustomMangaInfo,
+                restoreMangaStream(
+                    uri,
+                    if (options.categories) summary.backupCategories else emptyList(),
+                    summary.backupMangaMerges,
+                    summary.backupMangaUnmerges,
+                    summary.backupCustomMangaInfo,
                 )
             }
             if (options.extensionStores) {
-                restoreExtensionStores(backup)
+                restoreExtensionStores(summary.backupExtensionStores, summary.backupExtensions)
             }
             // RK -->
-            restoreNovels(backup, options)
+            restoreNovelsStream(uri, summary, options)
             // RK: novel plugins are NOT reinstalled here. Their install state (URLs + metadata) rides
             // the preference backup, so the normal lazy loader re-downloads them on the next novel-
             // screen open. A restore-time reinstall just duplicated that work and stalled on any
@@ -169,34 +176,125 @@ class BackupRestorer(
         }
     }
 
-    // RK: restore the light-novel library. Self-contained and sequential (categories first, then each
-    // novel, then the merge prefs) so it doesn't race the parallel manga/preference restore jobs.
-    private fun CoroutineScope.restoreNovels(backup: Backup, options: RestoreOptions) = launch {
+    // RK: pass 1. Decode only the small fields (kilobytes) and count the streamed library entries, so
+    // the restore never has to hold every manga / novel and their chapters in memory at once.
+    private suspend fun readBackupSummary(uri: Uri): BackupSummary {
+        val backupCategories = mutableListOf<BackupCategory>()
+        val backupSources = mutableListOf<BackupSource>()
+        val backupPreferences = mutableListOf<BackupPreference>()
+        val backupSourcePreferences = mutableListOf<BackupSourcePreferences>()
+        val backupExtensionStores = mutableListOf<BackupExtensionStore>()
+        val backupExtensions = mutableListOf<BackupExtension>()
+        val backupMangaMerges = mutableListOf<BackupMangaMergeGroup>()
+        val backupMangaUnmerges = mutableListOf<BackupMangaMergeGroup>()
+        val backupCustomMangaInfo = mutableListOf<BackupCustomMangaInfo>()
+        val backupNovelCategories = mutableListOf<BackupNovelCategory>()
+        val backupNovelMerges = mutableListOf<BackupNovelMergeGroup>()
+        val backupNovelUnmerges = mutableListOf<BackupNovelMergeGroup>()
+        val backupCustomNovelInfo = mutableListOf<BackupCustomNovelInfo>()
+        var mangaCount = 0
+        var novelCount = 0
+
+        BackupProtoReader(context).read(uri) { fieldNumber, data ->
+            when (fieldNumber) {
+                1 -> mangaCount++
+                700 -> novelCount++
+                2 -> backupCategories.add(parser.decodeFromByteArray(BackupCategory.serializer(), data))
+                101 -> backupSources.add(parser.decodeFromByteArray(BackupSource.serializer(), data))
+                104 -> backupPreferences.add(parser.decodeFromByteArray(BackupPreference.serializer(), data))
+                105 -> backupSourcePreferences.add(
+                    parser.decodeFromByteArray(BackupSourcePreferences.serializer(), data),
+                )
+                106 -> backupExtensionStores.add(parser.decodeFromByteArray(BackupExtensionStore.serializer(), data))
+                710 -> backupExtensions.add(parser.decodeFromByteArray(BackupExtension.serializer(), data))
+                711 -> backupMangaMerges.add(parser.decodeFromByteArray(BackupMangaMergeGroup.serializer(), data))
+                712 -> backupMangaUnmerges.add(parser.decodeFromByteArray(BackupMangaMergeGroup.serializer(), data))
+                713 -> backupCustomMangaInfo.add(parser.decodeFromByteArray(BackupCustomMangaInfo.serializer(), data))
+                701 -> backupNovelCategories.add(parser.decodeFromByteArray(BackupNovelCategory.serializer(), data))
+                702 -> backupNovelMerges.add(parser.decodeFromByteArray(BackupNovelMergeGroup.serializer(), data))
+                703 -> backupNovelUnmerges.add(parser.decodeFromByteArray(BackupNovelMergeGroup.serializer(), data))
+                714 -> backupCustomNovelInfo.add(parser.decodeFromByteArray(BackupCustomNovelInfo.serializer(), data))
+            }
+        }
+
+        return BackupSummary(
+            mangaCount = mangaCount,
+            novelCount = novelCount,
+            backupCategories = backupCategories,
+            backupSources = backupSources,
+            backupPreferences = backupPreferences,
+            backupSourcePreferences = backupSourcePreferences,
+            backupExtensionStores = backupExtensionStores,
+            backupExtensions = backupExtensions,
+            backupMangaMerges = backupMangaMerges,
+            backupMangaUnmerges = backupMangaUnmerges,
+            backupCustomMangaInfo = backupCustomMangaInfo,
+            backupNovelCategories = backupNovelCategories,
+            backupNovelMerges = backupNovelMerges,
+            backupNovelUnmerges = backupNovelUnmerges,
+            backupCustomNovelInfo = backupCustomNovelInfo,
+        )
+    }
+
+    private data class BackupSummary(
+        val mangaCount: Int,
+        val novelCount: Int,
+        val backupCategories: List<BackupCategory>,
+        val backupSources: List<BackupSource>,
+        val backupPreferences: List<BackupPreference>,
+        val backupSourcePreferences: List<BackupSourcePreferences>,
+        val backupExtensionStores: List<BackupExtensionStore>,
+        val backupExtensions: List<BackupExtension>,
+        val backupMangaMerges: List<BackupMangaMergeGroup>,
+        val backupMangaUnmerges: List<BackupMangaMergeGroup>,
+        val backupCustomMangaInfo: List<BackupCustomMangaInfo>,
+        val backupNovelCategories: List<BackupNovelCategory>,
+        val backupNovelMerges: List<BackupNovelMergeGroup>,
+        val backupNovelUnmerges: List<BackupNovelMergeGroup>,
+        val backupCustomNovelInfo: List<BackupCustomNovelInfo>,
+    )
+
+    // RK: restore the light-novel library, streamed. Categories first, then each novel in bounded
+    // batches, then the merge groups + custom-info overlay (both re-keyed from {url,source}).
+    private fun CoroutineScope.restoreNovelsStream(
+        uri: Uri,
+        summary: BackupSummary,
+        options: RestoreOptions,
+    ) = launch {
         if (options.categories) {
             ensureActive()
-            novelRestorer.restoreCategories(backup.backupNovelCategories)
+            novelRestorer.restoreCategories(summary.backupNovelCategories)
         }
         if (options.libraryEntries) {
-            backup.backupNovels
-                .chunked(100)
-                .forEach { chunk ->
-                    database.transaction {
-                        chunk.forEach { backupNovel ->
-                            ensureActive()
-                            try {
-                                novelRestorer.restore(backupNovel, backup.backupNovelCategories)
-                            } catch (e: Exception) {
-                                errors.add(Date() to "${backupNovel.title} [${backupNovel.source}]: ${e.message}")
-                            }
-
-                            restoreProgress.incrementAndFetch()
+            val batch = ArrayList<BackupNovel>(RESTORE_CHUNK)
+            suspend fun flush() {
+                if (batch.isEmpty()) return
+                database.transaction {
+                    batch.forEach { backupNovel ->
+                        ensureActive()
+                        try {
+                            novelRestorer.restore(backupNovel, summary.backupNovelCategories)
+                        } catch (e: Exception) {
+                            errors.add(Date() to "${backupNovel.title} [${backupNovel.source}]: ${e.message}")
                         }
+                        restoreProgress.incrementAndFetch()
                     }
-                    notifier.showRestoreProgress(chunk.last().title, restoreProgress.load(), restoreAmount, isSync)
                 }
-            novelRestorer.restoreMerges(backup.backupNovelMerges, backup.backupNovelUnmerges)
+                notifier.showRestoreProgress(batch.last().title, restoreProgress.load(), restoreAmount, isSync)
+                batch.clear()
+            }
+
+            BackupProtoReader(context).read(uri) { fieldNumber, data ->
+                if (fieldNumber != 700) return@read
+                ensureActive()
+                batch.add(parser.decodeFromByteArray(BackupNovel.serializer(), data))
+                if (batch.size >= RESTORE_CHUNK) flush()
+            }
+            flush()
+
+            novelRestorer.restoreMerges(summary.backupNovelMerges, summary.backupNovelUnmerges)
             // RK: apply the custom-info overlay, re-keyed from {url,source} to the fresh novel ids.
-            novelRestorer.restoreCustomNovelInfo(backup.backupCustomNovelInfo)
+            novelRestorer.restoreCustomNovelInfo(summary.backupCustomNovelInfo)
         }
     }
 
@@ -213,8 +311,12 @@ class BackupRestorer(
         )
     }
 
-    private fun CoroutineScope.restoreManga(
-        backupMangas: List<BackupManga>,
+    // RK: pass 2 for manga. Streams field 1, restoring bounded batches inside a DB transaction (each
+    // restore also opens its own, harmlessly nested), then materializes the merge groups + custom-info
+    // once every manga has a fresh id. The old whole-list sortByNew is dropped: entries restore
+    // independently and merges resolve by {url,source} after the loop, so file order is fine.
+    private fun CoroutineScope.restoreMangaStream(
+        uri: Uri,
         backupCategories: List<BackupCategory>,
         // RK: merge/unmerge groups, rebuilt from {url,source} once the restored manga have fresh IDs.
         backupMangaMerges: List<BackupMangaMergeGroup>,
@@ -222,25 +324,32 @@ class BackupRestorer(
         // RK: custom-info overlay, re-keyed from {url,source} to fresh IDs after the manga loop.
         backupCustomMangaInfo: List<BackupCustomMangaInfo>,
     ) = launch {
-        mangaRestorer.sortByNew(backupMangas)
-            .chunked(100)
-            .forEach { chunk ->
-                database.transaction {
-                    chunk.forEach {
-                        ensureActive()
-
-                        try {
-                            mangaRestorer.restore(it, backupCategories)
-                        } catch (e: Exception) {
-                            val sourceName = sourceMapping[it.source] ?: it.source.toString()
-                            errors.add(Date() to "${it.title} [$sourceName]: ${e.message}")
-                        }
-
-                        restoreProgress.incrementAndFetch()
+        val batch = ArrayList<BackupManga>(RESTORE_CHUNK)
+        suspend fun flush() {
+            if (batch.isEmpty()) return
+            database.transaction {
+                batch.forEach { backupManga ->
+                    ensureActive()
+                    try {
+                        mangaRestorer.restore(backupManga, backupCategories)
+                    } catch (e: Exception) {
+                        val sourceName = sourceMapping[backupManga.source] ?: backupManga.source.toString()
+                        errors.add(Date() to "${backupManga.title} [$sourceName]: ${e.message}")
                     }
+                    restoreProgress.incrementAndFetch()
                 }
-                notifier.showRestoreProgress(chunk.last().title, restoreProgress.load(), restoreAmount, isSync)
             }
+            notifier.showRestoreProgress(batch.last().title, restoreProgress.load(), restoreAmount, isSync)
+            batch.clear()
+        }
+
+        BackupProtoReader(context).read(uri) { fieldNumber, data ->
+            if (fieldNumber != 1) return@read
+            ensureActive()
+            batch.add(parser.decodeFromByteArray(BackupManga.serializer(), data))
+            if (batch.size >= RESTORE_CHUNK) flush()
+        }
+        flush()
 
         // RK: with every manga restored (fresh IDs), rebuild the merge prefs from the backup's refs.
         ensureActive()
@@ -283,10 +392,11 @@ class BackupRestorer(
     }
 
     private fun CoroutineScope.restoreExtensionStores(
-        backup: Backup,
+        backupExtensionStores: List<BackupExtensionStore>,
+        backupExtensions: List<BackupExtension>,
     ) = launch {
-        backup.backupExtensionStores
-            .chunked(100)
+        backupExtensionStores
+            .chunked(RESTORE_CHUNK)
             .forEach { chunk ->
                 database.transaction {
                     chunk.forEach {
@@ -313,7 +423,7 @@ class BackupRestorer(
         // missing can't be matched; log them so the user knows what to reinstall by hand.
         ensureActive()
         try {
-            extensionRestorer.restore(backup.backupExtensions).forEach { name ->
+            extensionRestorer.restore(backupExtensions).forEach { name ->
                 errors.add(Date() to "Extension not reinstalled (repo missing): $name")
             }
         } catch (e: Exception) {
@@ -338,5 +448,11 @@ class BackupRestorer(
             // Empty
         }
         return File("")
+    }
+
+    companion object {
+        // RK: entries per DB transaction while streaming; also the memory bound (only this many
+        // entries + their chapters are resident at once).
+        private const val RESTORE_CHUNK = 100
     }
 }

--- a/app/src/test/java/eu/kanade/tachiyomi/data/backup/BackupStreamFramingTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/data/backup/BackupStreamFramingTest.kt
@@ -1,0 +1,98 @@
+package eu.kanade.tachiyomi.data.backup
+
+import eu.kanade.tachiyomi.data.backup.create.BackupProtoWriter
+import eu.kanade.tachiyomi.data.backup.models.Backup
+import eu.kanade.tachiyomi.data.backup.models.BackupCategory
+import eu.kanade.tachiyomi.data.backup.models.BackupCustomMangaInfo
+import eu.kanade.tachiyomi.data.backup.models.BackupCustomNovelInfo
+import eu.kanade.tachiyomi.data.backup.models.BackupExtension
+import eu.kanade.tachiyomi.data.backup.models.BackupManga
+import eu.kanade.tachiyomi.data.backup.models.BackupMangaMergeGroup
+import eu.kanade.tachiyomi.data.backup.models.BackupMangaSourceRef
+import eu.kanade.tachiyomi.data.backup.models.BackupNovel
+import eu.kanade.tachiyomi.data.backup.models.BackupNovelCategory
+import eu.kanade.tachiyomi.data.backup.models.BackupNovelMergeGroup
+import eu.kanade.tachiyomi.data.backup.models.BackupNovelSourceRef
+import eu.kanade.tachiyomi.data.backup.models.BackupSource
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.SerializationStrategy
+import kotlinx.serialization.protobuf.ProtoBuf
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayOutputStream
+
+/**
+ * The streamed backup hand-writes each top-level protobuf field (BackupProtoWriter) instead of
+ * encoding the whole Backup at once. A wrong field number or a varint bug would silently corrupt or
+ * drop data on a user's backup, so this proves the streamed bytes decode back through the real
+ * Backup serializer, across every Reikai (700+) field. If a field number drifts, this fails to
+ * build, not on a restore.
+ */
+class BackupStreamFramingTest {
+
+    private val proto = ProtoBuf
+
+    private fun <T> ByteArrayOutputStream.write(fieldNumber: Int, serializer: SerializationStrategy<T>, item: T) {
+        BackupProtoWriter.writeField(this, fieldNumber, proto.encodeToByteArray(serializer, item))
+    }
+
+    @Test
+    fun `streamed fields decode back through the Backup serializer`() {
+        val out = ByteArrayOutputStream()
+
+        // Two manga to prove repeated framing, plus every content type and each RK field.
+        out.write(1, BackupManga.serializer(), BackupManga(source = 1L, url = "m1", title = "Manga 1"))
+        out.write(1, BackupManga.serializer(), BackupManga(source = 2L, url = "m2", title = "Manga 2"))
+        out.write(700, BackupNovel.serializer(), BackupNovel(source = "ns", url = "n1", title = "Novel 1"))
+        out.write(2, BackupCategory.serializer(), BackupCategory(name = "Cat"))
+        out.write(101, BackupSource.serializer(), BackupSource(name = "Src", sourceId = 1L))
+        out.write(710, BackupExtension.serializer(), BackupExtension(pkgName = "pkg", name = "Ext"))
+        out.write(
+            711,
+            BackupMangaMergeGroup.serializer(),
+            BackupMangaMergeGroup(refs = listOf(BackupMangaSourceRef("a", 1L), BackupMangaSourceRef("b", 2L))),
+        )
+        out.write(
+            712,
+            BackupMangaMergeGroup.serializer(),
+            BackupMangaMergeGroup(refs = listOf(BackupMangaSourceRef("c", 3L), BackupMangaSourceRef("d", 4L))),
+        )
+        out.write(
+            713,
+            BackupCustomMangaInfo.serializer(),
+            BackupCustomMangaInfo(source = 1L, url = "m1", title = "Custom Manga"),
+        )
+        out.write(701, BackupNovelCategory.serializer(), BackupNovelCategory(name = "NCat"))
+        out.write(
+            702,
+            BackupNovelMergeGroup.serializer(),
+            BackupNovelMergeGroup(refs = listOf(BackupNovelSourceRef("na", "ns1"), BackupNovelSourceRef("nb", "ns2"))),
+        )
+        out.write(
+            703,
+            BackupNovelMergeGroup.serializer(),
+            BackupNovelMergeGroup(refs = listOf(BackupNovelSourceRef("nc", "ns3"), BackupNovelSourceRef("nd", "ns4"))),
+        )
+        out.write(
+            714,
+            BackupCustomNovelInfo.serializer(),
+            BackupCustomNovelInfo(source = "ns", url = "n1", title = "Custom Novel"),
+        )
+
+        val backup = proto.decodeFromByteArray(Backup.serializer(), out.toByteArray())
+
+        backup.backupManga.map { it.url } shouldBe listOf("m1", "m2")
+        backup.backupNovels shouldHaveSize 1
+        backup.backupNovels.first().title shouldBe "Novel 1"
+        backup.backupCategories.single().name shouldBe "Cat"
+        backup.backupSources.single().sourceId shouldBe 1L
+        backup.backupExtensions.single().name shouldBe "Ext"
+        backup.backupMangaMerges.single().refs.map { it.url } shouldBe listOf("a", "b")
+        backup.backupMangaUnmerges.single().refs.map { it.url } shouldBe listOf("c", "d")
+        backup.backupCustomMangaInfo.single().title shouldBe "Custom Manga"
+        backup.backupNovelCategories.single().name shouldBe "NCat"
+        backup.backupNovelMerges.single().refs.map { it.source } shouldBe listOf("ns1", "ns2")
+        backup.backupNovelUnmerges.single().refs.map { it.source } shouldBe listOf("ns3", "ns4")
+        backup.backupCustomNovelInfo.single().title shouldBe "Custom Novel"
+    }
+}

--- a/app/src/test/java/eu/kanade/tachiyomi/data/backup/NovelBackupRoundTripTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/data/backup/NovelBackupRoundTripTest.kt
@@ -79,13 +79,14 @@ class NovelBackupRoundTripTest {
     @Test
     fun `merge groups survive an id remap across backup then restore`() = runTest {
         // Backup side: a manual merge "1,5" over two favorited novels on different sources.
-        val favorites = listOf(novel(1, "a", "s1"), novel(5, "b", "s2"))
         val backupPrefs = mockk<ReikaiLibraryPreferences> {
             every { novelManualMerges } returns pref(setOf("1,5"))
             every { novelManualUnmerges } returns pref(emptySet())
         }
+        // The streamed backup holds no favorites list, so each member resolves by id.
         val backupRepo = mockk<NovelRepository> {
-            coEvery { getFavorites() } returns favorites
+            coEvery { getById(1) } returns novel(1, "a", "s1")
+            coEvery { getById(5) } returns novel(5, "b", "s2")
         }
         val creator = NovelBackupCreator(
             novelRepository = backupRepo,
@@ -105,10 +106,10 @@ class NovelBackupRoundTripTest {
             history = false,
         )
 
-        val data = creator(options)
+        val merges = creator.novelMerges(options)
 
         // The group is serialized as stable {url, source} refs, not the raw ids.
-        data.merges.map { group -> group.refs.map { it.url to it.source } } shouldContainExactly
+        merges.map { group -> group.refs.map { it.url to it.source } } shouldContainExactly
             listOf(listOf("a" to "s1", "b" to "s2"))
 
         // Restore side: the same two novels come back with fresh ids 10 and 20.
@@ -134,7 +135,7 @@ class NovelBackupRoundTripTest {
             database = mockk(relaxed = true),
         )
 
-        restorer.restoreMerges(data.merges, emptyList())
+        restorer.restoreMerges(merges, emptyList())
 
         // The merge is rebuilt against the restored ids, sorted and comma-joined as the pref expects.
         mergeSlot.captured shouldBe setOf("10,20")

--- a/docs/dev/upstream-sync.md
+++ b/docs/dev/upstream-sync.md
@@ -42,7 +42,9 @@ Reference upstream PRs/issues as **`mihonapp/mihon#<n>`** (a cross-repo link). A
 
 ## Deliberate divergences from upstream
 
-Cases where Reikai knowingly does not match `refs/mihon`, so a future syncer does not "fix" them back. Revisit each when upstream settles. None are active right now.
+Cases where Reikai knowingly does not match `refs/mihon`, so a future syncer does not "fix" them back. Revisit each when upstream settles.
+
+- **Backup create / validate / restore are streamed, not whole-file.** `BackupCreator`, `BackupFileValidator`, and `BackupRestorer` diverge from Mihon's `encodeToByteArray(Backup.serializer(), backup)` / `decode()` (which build the whole `Backup` in memory and OOM on a large library, unseensnick/Reikai#53). Reikai writes each top-level protobuf field to the gzip sink and reads it back one field at a time (`BackupProtoWriter` / `BackupProtoReader`), so a future sync of these three files is a hand-merge inside the `// RK` islands, never a verbatim copy. The wire format is unchanged (same field numbers), so backups stay cross-compatible with upstream.
 
 _Previously:_
 

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -257,6 +257,8 @@
     <string name="content_type_all">All</string>
     <string name="content_type_manga">Manga</string>
     <string name="content_type_novels">Novels</string>
+    <!-- RK: backup toggle for the non-destructive custom-info overlay (title/author/cover edits) -->
+    <string name="custom_entry_info">Custom entry info</string>
     <!-- RK: Updates group-by-series -->
     <string name="updates_group_by_series">Group by series</string>
     <string name="updates_group_chapter_count">%1$d new chapters</string>


### PR DESCRIPTION
Backing up a large library with chapters enabled produced a blank 0 KB file and a progress notification that vanished with no error, so affected users have been running with no backup at all. This backports the streaming fix onto the stable line and cuts 0.3.1.

Closes unseensnick/Reikai#53.

## What changed

- Create, validate and restore stream the backup one field at a time to and from the gzip file, so memory stays bounded to a small batch instead of the whole library.
- A failed backup reports the error and removes the partial file instead of stopping silently. The catch widened to `Throwable`, since an `OutOfMemoryError` is an `Error` and slipped the old `Exception`-only catch.
- Create backup gains Manga, Novels and Custom entry info toggles.
- `versionCode` 184, `versionName` 0.3.1.

## Porting note

Hand-ported from `a99f83daa` on `feat/0.4.0` rather than cherry-picked: that commit builds on the merge-group tables 0.4.0 adds, which conflicts in five files. Merge and unmerge groups stay preference-backed here, so fields 711/712 and 702/703 are all still written. Expect a conflict in these files when `feat/0.4.0` merges later, and take the 0.4.0 side wholesale there.

## Verification

- A 0.3.1 backup of a real library is byte-identical to the 0.3.0 one it replaces: same SHA-256 over 8,573,510 inflated bytes, same per-field counts.
- A 0.3.0-written backup restores into a fresh install in 1 min 33 sec with 0 errors, with chapter counts and merge grouping intact.
- A novel-bearing backup (22.6 MB inflated, 64 novels) restores in 21 sec with 0 errors, and 0.3.1 writes the novel entries, categories and merge groups back out.
- In-place upgrade from 0.3.0 keeps library and settings.
- 386 unit tests pass; the framing golden-check covers the unmerge fields, verified by mutating the length varint.