### PR TITLE
fix(ci): correct preview release ordering and notes

### DIFF
--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Clone repo
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -39,13 +39,13 @@ jobs:
           ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager "build-tools;35.0.0"
 
       - name: Set up JDK
-        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           java-version-file: .github/.java-version
           distribution: temurin
 
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
+        uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
 
       - name: Copy CI gradle.properties
         run: |

--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone repo
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Lint CHANGELOG.md, ROADMAP.md, upstream-sync.md and feature-ports.md
         run: |

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -46,18 +46,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone repo
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
       - name: Set up JDK
-        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           java-version-file: .github/.java-version
           distribution: temurin
 
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
+        uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
 
       - name: Setup Android SDK
         run: ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager "build-tools;35.0.0"

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -158,12 +158,36 @@ jobs:
           mv "$d/app-x86-preview.apk"          "reikai-x86-r${COMMIT_COUNT}.apk"
           mv "$d/app-x86_64-preview.apk"       "reikai-x86_64-r${COMMIT_COUNT}.apk"
 
+      - name: Stamp a dated commit for this release to hang on
+        env:
+          GH_TOKEN: ${{ secrets.PREVIEW_REPO_TOKEN }}
+        run: |
+          set -e
+          # The releases page orders by the TAG's commit date, not the publish date. Every preview tag
+          # used to point at the preview repo's single LICENSE commit, so that key tied across all of
+          # them and GitHub fell back to comparing tag names as strings, which sorts r1350 below r380.
+          # Each release now gets its own commit dated at build time, so the primary sort works and the
+          # tie-break never runs. The commit reuses main's tree and hangs off it as a sibling, reachable
+          # only through its tag, so the preview repo's own history stays a single LICENSE commit.
+          base=$(gh api "repos/$PREVIEW_REPO/git/ref/heads/main" --jq '.object.sha')
+          tree=$(gh api "repos/$PREVIEW_REPO/commits/main" --jq '.commit.tree.sha')
+          bot='{"name":"github-actions[bot]","email":"41898282+github-actions[bot]@users.noreply.github.com"}'
+          stamp=$(jq -n --arg m "preview r${COMMIT_COUNT}" --arg t "$tree" --arg p "$base" \
+                        --arg d "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --argjson who "$bot" \
+                    '{message:$m, tree:$t, parents:[$p],
+                      author:    ($who + {date:$d}),
+                      committer: ($who + {date:$d})}' \
+                  | gh api "repos/$PREVIEW_REPO/git/commits" --input - --jq '.sha')
+          echo "STAMP_SHA=$stamp" >> "$GITHUB_ENV"
+
       - name: Publish preview release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           repository: ${{ env.PREVIEW_REPO }}
           token: ${{ secrets.PREVIEW_REPO_TOKEN }}
           tag_name: r${{ env.COMMIT_COUNT }}
+          # Creates the tag on the stamp commit above, which is what dates the release.
+          target_commitish: ${{ env.STAMP_SHA }}
           name: Reikai Preview r${{ env.COMMIT_COUNT }}
           body: |
             ${{ env.RELEASE_BODY }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -203,8 +203,12 @@ jobs:
           # Creates the tag on the stamp commit above, which is what dates the release.
           target_commitish: ${{ env.STAMP_SHA }}
           name: Reikai Preview r${{ env.COMMIT_COUNT }}
+          # The in-app update dialog shows this body only up to the last <!--> marker (see
+          # ReleaseServiceImpl), so the download note below it stays GitHub-only.
           body: |
             ${{ env.RELEASE_BODY }}
+
+            <!-->
 
             > If you are unsure which to download, use `reikai-r${{ env.COMMIT_COUNT }}.apk` (universal).
           files: |

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -97,16 +97,28 @@ jobs:
           commit_count=$(git rev-list --count HEAD)
           echo "COMMIT_COUNT=$commit_count" >> "$GITHUB_ENV"
 
-          # Resolve the previous preview's commit: preview tags are r<commitCount>, so the commit it was
-          # cut from is HEAD~(count - prevCount).
+          # Resolve the previous preview's source commit by reading it back off that release's stamp
+          # commit, which records it. The old arithmetic (HEAD~(count - prevCount)) assumed every preview
+          # was cut from the same branch: counts on main and on a feature branch are unrelated, so a
+          # preview following one built elsewhere silently diffed against a stranger commit that happened
+          # to sit that far back, and the notes listed the whole [Unreleased] section.
           prev_ref=""
           prev_tag=$(gh release list --repo "$PREVIEW_REPO" --json tagName --limit 1 --jq 'select(length > 0) | .[0].tagName' || true)
           if [ -n "$prev_tag" ]; then
-            back=$((commit_count - ${prev_tag#r}))
-            if [ "$back" -ge 0 ] && git rev-parse -q --verify "HEAD~$back" >/dev/null 2>&1; then
-              prev_ref="HEAD~$back"
+            prev_sha=$(gh api "repos/$PREVIEW_REPO/commits/$prev_tag" --jq '.commit.message' 2>/dev/null \
+                       | sed -n 's/^preview r[0-9]* (\([0-9a-f]\{7,40\}\))$/\1/p' | head -1)
+            if [ -n "$prev_sha" ] && git cat-file -e "${prev_sha}^{commit}" 2>/dev/null; then
+              if git merge-base --is-ancestor "$prev_sha" HEAD; then
+                prev_ref="$prev_sha"
+              else
+                # That preview came off another branch, so the honest base is where the two diverged.
+                prev_ref=$(git merge-base "$prev_sha" HEAD || true)
+              fi
             fi
           fi
+          # A stamp with no recorded commit (or one this clone cannot see) leaves prev_ref empty, and the
+          # notes fall back to the whole [Unreleased] section rather than to a guess.
+          echo "Previous preview ${prev_tag:-none}, diffing against ${prev_ref:-nothing}"
 
           # Preview notes are the entries ADDED to CHANGELOG.md's [Unreleased] since the previous preview
           # (the running list would otherwise repeat every build). Diff the current [Unreleased] against
@@ -169,10 +181,12 @@ jobs:
           # Each release now gets its own commit dated at build time, so the primary sort works and the
           # tie-break never runs. The commit reuses main's tree and hangs off it as a sibling, reachable
           # only through its tag, so the preview repo's own history stays a single LICENSE commit.
+          # The message records the Reikai commit this preview was built from, in the exact shape the
+          # release-body step parses to find the previous preview's base. Keep the two in step.
           base=$(gh api "repos/$PREVIEW_REPO/git/ref/heads/main" --jq '.object.sha')
           tree=$(gh api "repos/$PREVIEW_REPO/commits/main" --jq '.commit.tree.sha')
           bot='{"name":"github-actions[bot]","email":"41898282+github-actions[bot]@users.noreply.github.com"}'
-          stamp=$(jq -n --arg m "preview r${COMMIT_COUNT}" --arg t "$tree" --arg p "$base" \
+          stamp=$(jq -n --arg m "preview r${COMMIT_COUNT} ($(git rev-parse HEAD))" --arg t "$tree" --arg p "$base" \
                         --arg d "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --argjson who "$bot" \
                     '{message:$m, tree:$t, parents:[$p],
                       author:    ($who + {date:$d}),

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,8 +141,13 @@ jobs:
         with:
           tag_name: ${{ env.VERSION_TAG }}
           name: Reikai ${{ env.VERSION_TAG }}
+          # The in-app update dialog shows this body only up to the last <!--> marker (see
+          # ReleaseServiceImpl), so the download guidance and checksums below it stay GitHub-only.
           body: |
             ${{ env.RELEASE_BODY }}
+
+            <!-->
+
             ${{ env.CHECKSUMS }}
 
             > If you are unsure which to download, use `reikai-${{ env.VERSION_TAG }}.apk` (universal).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,18 +32,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone repo
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
       - name: Set up JDK
-        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           java-version-file: .github/.java-version
           distribution: temurin
 
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
+        uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
 
       - name: Setup Android SDK
         run: ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager "build-tools;35.0.0"


### PR DESCRIPTION
The preview releases page listed the newest build last, and a preview's
notes sometimes repeated the entire unreleased changelog instead of what
had changed since the previous one. Both are fixed here, along with a
refresh of the shared action pins.

### Ordering

GitHub orders the releases page by the tag's commit date, not the publish
date. Every preview tag pointed at the preview repo's single LICENSE
commit, so that date tied across all of them and the page fell back to
comparing tag names as text, which sorts `r1350` below `r380`. Each
release now gets its own commit dated when it was built, so the primary
sort works and the tie-break never runs. A release's "Source code"
archive also stops claiming it was made the day the preview repo got its
LICENSE.

The 29 existing releases were repointed the same way as a one-off, which
moved each to its real publish date with its five APK assets and their
download URLs untouched.

### Notes

A preview found the previous build by counting commits backwards, which
only holds while every preview comes off the same branch. A build
following one cut elsewhere diffed against an unrelated commit and listed
everything. Each preview now records the commit it was built from and the
next one reads it back. A preview following one from another branch
diffs from where the two branches parted, and when the previous build
recorded nothing the notes fall back to the full list rather than a
guess.

### Also

- The `<!-->` marker now separates the release notes from the checksums
  and download guidance, so the in-app update dialog shows only the notes.
  The app already strips it.
- `actions/checkout` v7.0.0 to v7.0.1, `actions/setup-java` v5.5.0 to
  v5.7.0, `gradle/actions/setup-gradle` v6.2.0 to v6.3.0, matching what
  the 0.4.0 branch already builds with.

Workflows only, so nothing here changes the app. Deliberately left for
0.4.0 to carry: the comment-cap and codename hooks (main's tree has 115
lines that would fail the check), the off-path manifest check (main has
no manifest for it to read), and the telemetry and FOSS APK CI (needs
gradle wiring that only exists on that branch).
