### PR TITLE
Write the Gradle cache off the release branch, uncap CI workers

### DIFF
--- a/.github/runner-files/ci-gradle.properties
+++ b/.github/runner-files/ci-gradle.properties
@@ -1,5 +1,7 @@
 org.gradle.daemon=false
 org.gradle.jvmargs=-Xmx5120m
-org.gradle.workers.max=2
+# No workers.max: Gradle then defaults to the runner's processor count, which is 4 on the public-repo
+# ubuntu-latest image. The old cap of 2 halved the parallelism `org.gradle.parallel=true` asks for,
+# and hard-coding 4 here would go stale the next time GitHub resizes the image.
 
 kotlin.incremental=false

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -126,6 +126,14 @@ jobs:
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+        with:
+          # The action writes the Gradle cache only from the default branch by default, and preview
+          # builds run almost entirely from the release branch (feat/**), so every one of them was
+          # restoring whatever main last wrote and discarding its own dependencies, transforms and
+          # build-cache entries. Writing here keeps a release branch warm across its own cycle.
+          # Not done on release.yml: a tag ref's cache is restorable only by that same tag, so a
+          # release build can read main's cache but writing one would never be read again.
+          cache-read-only: false
 
       - name: Setup Android SDK
         run: ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager "build-tools;35.0.0"


### PR DESCRIPTION
Preview builds were throwing away everything they compiled, and running at half the parallelism the runner can give.

## The cache

`gradle/actions/setup-gradle` writes the Gradle cache only from the default branch unless told otherwise. `preview.yml` triggers on `feat/**` and `fix/**`, which is where a whole release cycle happens, so every preview build this cycle restored whatever `main` last wrote and then discarded its own dependencies, transforms and `build-cache-1` entries. Since `main` only receives app-affecting commits at the merge, that restored cache goes steadily staler through the cycle.

`cache-read-only: false` on the preview build job fixes it. `release.yml` is deliberately left alone: a cache created on a tag ref is restorable only by that same tag, so a release build can read `main`'s cache but anything it wrote would never be read again.

## The workers

`ci-gradle.properties` set `org.gradle.workers.max=2` while `gradle.properties` asks for parallel builds. The public-repo `ubuntu-latest` image has 4 cores, so that capped the build at half of them. Dropping the line lets Gradle default to the processor count, which also avoids going stale the next time the image is resized.

## Notes

Nothing here changes the APK. The preview `paths` allow-list excludes `.github`, so merging this will not itself trigger a build; the next code push is what shows the effect. Recent preview runs took 13 to 15 minutes, which is the baseline to compare against.

Not taken here: the Gradle configuration cache. It is the larger win and the riskier change, since it is repo-wide and depends on AGP, moko-resources and `build-logic` all cooperating, so it wants its own investigation rather than a line in a CI file.