### PR TITLE
fix(ci): link a build's changelog to the commit it came from

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -219,7 +219,10 @@ jobs:
               echo ""
               echo "$new_lines"
               echo ""
-              printf '**Full changelog:** %s/blob/main/CHANGELOG.md\n' "$repo"
+              # Pin the link to the commit this build came from, not to a branch. A preview is usually
+              # cut from a feature branch, so blob/main pointed at a changelog that does not contain the
+              # entries listed above it, and a branch link would 404 once that branch is merged away.
+              printf '**Full changelog:** %s/blob/%s/CHANGELOG.md\n' "$repo" "${{ github.sha }}"
             else
               commits=""
               if [ -n "$prev_ref" ]; then


### PR DESCRIPTION
A preview is usually cut from a feature branch, but the release body links `CHANGELOG.md` on `main`, which does not contain the entries the notes above it just listed. That means fixing the link by hand on every build.

- The link now points at the exact commit the build came from, so it shows the changelog as it stood in that build.
- A commit link rather than a branch link, since a branch one would 404 for every past build once that branch is merged away.

`release.yml` is deliberately untouched: a stable release is cut from `main`, so `main`'s changelog is the right living reference there.

Cut against `main` rather than cherry-picked from `feat/0.4.0`, because that branch has since renamed the workflow to `nightly.yml` and the surrounding indentation differs. Same fix, applied to the file `main` actually has.