### PR TITLE
Rename the app to app.reikai and cut 0.3.2

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -27,7 +27,7 @@ No `Injekt.get<>()` / `injectLazy()` inside a `@Composable` body.
 
 ## Minification (R8) and net-new packages
 
-Release-type builds (`release` / `preview` / `foss`) are minified (`isMinifyEnabled = Config.enableCodeShrink`); the `debugY2k` dev build is NOT, so R8-only bugs are invisible in the normal dev loop. The recurring one: R8 strips the generic `Signature` that Injekt's `FullTypeReference` reflects on, so an `Injekt.get<T>()` / `injectLazy<T>()` in a package that is not in the proguard keep list crashes the minified build with `IllegalArgumentException: Internal error: TypeReference constructed without actual type information`.
+Release-type builds (`release` / `preview` / `foss`) are minified (`isMinifyEnabled = Config.enableCodeShrink`); the `debug` dev build is NOT, so R8-only bugs are invisible in the normal dev loop. The recurring one: R8 strips the generic `Signature` that Injekt's `FullTypeReference` reflects on, so an `Injekt.get<T>()` / `injectLazy<T>()` in a package that is not in the proguard keep list crashes the minified build with `IllegalArgumentException: Internal error: TypeReference constructed without actual type information`.
 
 `app/proguard-rules.pro` keeps the upstream packages (`eu.kanade.**` / `tachiyomi.**` / `mihon.**`) plus every net-new top-level package: `reikai.**` and `exh.**`. **When you add a new top-level package that uses Injekt generics, add its own `-keep,allowoptimization class <pkg>.**` line.** Past crashes: `NovelUpdateJob.setupTask` -> `Injekt.get<NovelPreferences>()` (startup); `EHentaiUpdateWorker.setupTask` -> `Injekt.get<ExhPreferences>()` (toggling the E-Hentai gallery-update schedule).
 

--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -152,4 +152,4 @@ Any remaining Reikai-own feature (the parity backlog is mostly shipped) is porte
 
 ## Identity (preserve through the rebase)
 
-Keep Reikai identity as-is when porting: `applicationId = "eu.kanade.tachiyomi"` + `.y2k` / `.debugY2k` suffix, app name `Reikai` (i18n), `google-services.json` (gitignored, never committed), README/CHANGELOG fork sections, the `// RK` marker convention. Take Mihon for everything else.
+Keep Reikai identity as-is when porting: `applicationId = "app.reikai"` with upstream's build-type suffixes, app name `Reikai` (i18n), `google-services.json` (gitignored, never committed), README/CHANGELOG fork sections, the `// RK` marker convention. Take Mihon for everything else.

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -6,97 +6,162 @@
 #     (Other is exempt), under a length cap.
 #   ROADMAP.md - forward-only backlog stays name-clean: no content-source names, no em dash, no
 #     bare #N (use "Roadmap N" or owner/repo#N). Shipped detail lives in docs/dev/shipped.md.
+#   .kt comments - no plan/roadmap codename markers (Phase N, P5 S5, Y3, R3, Active #N, plan-style
+#     Step N) in newly added lines; they rot. State the durable fact instead (R8 and M3 are spared).
+#   .kt comment blocks under reikai/ or exh/ - a run of consecutive comment lines is capped at 8; a
+#     9th is rejected. See .claude/rules/code-quality.md "Comments".
 # Tracked here as the source of truth; activate on a clone with:
 #   cp .githooks/pre-commit .git/hooks/ && chmod +x .git/hooks/pre-commit
 set -u
 
 staged() { git diff --cached --name-only | grep -qx "$1"; }
-# Content-source names (adult + mainstream) that must be genericized or use an approved shorthand
-# (EH / ExH / MD / CMK) in the public-facing docs. Trackers (MangaUpdates, Shikimori, AniList, ...) are NOT
-# sources and stay allowed. Extend this list as new sources get named in the repo.
-deny='e-hentai|ehentai|exhentai|nhentai|pururin|8muses|hentaifox|asmhentai|koharu|schalenetwork|mangadex|comick'
 fail=0
+
+# The rules themselves live in scripts/lint-docs.sh, which .github/workflows/docs-lint.yml also
+# calls. The hook decides WHAT to check (the staged content) and the script decides what counts as
+# a violation, so the two enforcers cannot drift apart.
+lint() { bash scripts/lint-docs.sh "$@" || fail=1; }
+scratch_a=$(mktemp); scratch_b=$(mktemp)
+trap 'rm -f "$scratch_a" "$scratch_b"' EXIT
 
 # ===== CHANGELOG.md =====
 if staged CHANGELOG.md; then
-  # 1) No content-source names in any newly added CHANGELOG line.
-  bad_names=$(git diff --cached -U0 -- CHANGELOG.md | grep -E '^\+[^+]' | grep -inE "$deny" || true)
-  if [ -n "$bad_names" ]; then
-    echo "CHANGELOG: a new line names a content source, genericize it (see Public-facing naming):"
-    echo "$bad_names"
-    fail=1
-  fi
+  # Source names are checked on newly added lines only: already-released entries are never rewritten.
+  git diff --cached -U0 -- CHANGELOG.md | grep -E '^\+[^+]' > "$scratch_a" || true
+  lint source-names "$scratch_a" "CHANGELOG"
 
-  # 2) Structure of the staged [Unreleased] section (only [Unreleased] is checked).
-  issues=$(git show :CHANGELOG.md | awk '
-    /^## \[Unreleased\]/ { u=1; next }
-    /^## \[/             { u=0 }
-    !u                  { next }
-    /^### /             { sec=$0; sub(/^### /,"",sec); next }
-    /^\*\*/             { next }
-    /^- / {
-      if (length($0) > 320)
-        print "  - over the length cap (>320 chars); trim to a bold headline + one sentence:\n    " $0
-      if (sec != "Other" && $0 !~ /^- \*\*[^*]+[.!?]\*\*/)
-        print "  - needs a self-contained bold headline ending in . ! or ? (Other is exempt):\n    " $0
-    }
-  ')
-  if [ -n "$issues" ]; then
-    echo "CHANGELOG [Unreleased] entry issues:"
-    echo "$issues"
-    fail=1
-  fi
+  # Entry shape is checked on the whole staged [Unreleased] section, since an entry can be edited
+  # into a bad shape by a line that does not itself look wrong.
+  git show :CHANGELOG.md > "$scratch_b"
+  lint changelog-entries "$scratch_b"
 fi
 
 # ===== ROADMAP.md =====
 if staged ROADMAP.md; then
-  road=$(git show :ROADMAP.md)
+  git show :ROADMAP.md > "$scratch_a"
+  lint source-names "$scratch_a" "ROADMAP"
+  lint em-dash "$scratch_a" "ROADMAP"
+  lint issue-refs "$scratch_a" "ROADMAP" "'Roadmap N' or owner/repo#N"
+fi
 
-  # 1) No content-source names anywhere (use EH / ExH shorthand or generic wording).
-  rn=$(printf '%s\n' "$road" | grep -inE "$deny" || true)
-  if [ -n "$rn" ]; then
-    echo "ROADMAP: names a content source, use an approved shorthand (EH / ExH / MD / CMK) or generic wording"
-    echo "(specific source names belong in docs/dev/shipped.md and the plan docs, not the forward roadmap):"
-    echo "$rn"
-    fail=1
+# ===== the dev sync records (content-source names are allowed: they are dev records) =====
+for doc in docs/dev/upstream-sync.md docs/dev/feature-ports.md; do
+  if staged "$doc"; then
+    git show ":$doc" > "$scratch_a"
+    lint em-dash "$scratch_a" "$doc"
+    lint issue-refs "$scratch_a" "$doc" "owner/repo#N (mihonapp/mihon#N for upstream)"
   fi
+done
 
-  # 2) No em dash.
-  em=$(printf '%s\n' "$road" | grep -n '—' || true)
-  if [ -n "$em" ]; then
-    echo "ROADMAP: contains an em dash; use commas, parentheses, periods or colons:"
-    echo "$em"
-    fail=1
+# ===== DI ownership: graph-owned, singleton, and never Injekt-registered as well =====
+# All three mistakes are silent at build and run time: two instances of a type lose state, and a
+# missed annotation keeps working on the Injekt registration. See docs/dev/plans/metro-di-migration.md.
+# The trigger is the staged content, not a path list: a path list goes stale as the port deletes files,
+# and the mistake usually lands on an ordinary annotated class rather than on a module file.
+di_touched=0
+for f in $(git diff --cached --name-only --diff-filter=d | grep '\.kt$'); do
+  if git show ":$f" 2>/dev/null | grep -qE 'dev\.zacsweers\.metro|InjektModule|addSingletonFactory|addFactory'; then
+    di_touched=1
+    break
   fi
-
-  # 3) No bare #N (a '#' + digits not preceded by an alphanumeric; owner/repo#N is fine).
-  hn=$(printf '%s\n' "$road" | grep -nE '(^|[^A-Za-z0-9])#[0-9]' || true)
-  if [ -n "$hn" ]; then
-    echo "ROADMAP: bare '#N' auto-links to a Reikai issue, use 'Roadmap N' or owner/repo#N:"
-    echo "$hn"
-    fail=1
+done
+if [ "$di_touched" -eq 1 ] && [ -f scripts/di-interop-check.ps1 ]; then
+  if command -v pwsh >/dev/null 2>&1; then
+    if ! pwsh -NoProfile -File scripts/di-interop-check.ps1; then
+      fail=1
+    fi
+  else
+    echo "di-interop-check: pwsh not found, skipping (run scripts/di-interop-check.ps1 by hand)."
   fi
 fi
 
-# ===== docs/dev/upstream-sync.md (content-source names allowed here: it is a dev record) =====
-if staged docs/dev/upstream-sync.md; then
-  sync=$(git show :docs/dev/upstream-sync.md)
+# ===== code comments (.kt/.kts/.sq/.sqm): no plan/roadmap codename markers (they rot) =====
+# Only newly added comment lines are scanned; the patterns live in scripts/lint-docs.sh so CI's
+# whole-tree pass enforces exactly the same rule.
+git diff --cached -U0 --diff-filter=ACM -- '*.kt' '*.kts' '*.sq' '*.sqm' | grep -E '^\+' | grep -vE '^\+\+\+' > "$scratch_a" || true
+lint codenames --stdin < "$scratch_a"
 
-  # No em dash.
-  em=$(printf '%s\n' "$sync" | grep -n '—' || true)
-  if [ -n "$em" ]; then
-    echo "upstream-sync: contains an em dash; use commas, parentheses, periods or colons:"
-    echo "$em"
-    fail=1
-  fi
+# ===== code comments (.kt/.kts/.sq/.sqm): no calendar dates =====
+# A date stamps when someone looked, which is what git already records, and it reads as an expiry the
+# code does not have. State the durable fact instead, and let the plan doc carry when it was measured.
+# Only 20xx-MM-DD is matched, so a format string ("yyyy-MM-dd") and an epoch (1970-01-01) are spared.
+datestamps=$(git diff --cached -U0 --diff-filter=ACM -- '*.kt' '*.kts' '*.sq' '*.sqm' \
+  | grep -E '^\+' | grep -vE '^\+\+\+' \
+  | grep -E '(//|/\*|^\+[[:space:]]*\*|^\+[[:space:]]*--)' \
+  | grep -E '\b20[0-9]{2}-[01][0-9]-[0-3][0-9]\b' || true)
+if [ -n "$datestamps" ]; then
+  echo "code comments: drop the calendar date, state the durable fact instead"
+  echo "(git records when; the plan doc records what was measured):"
+  echo "$datestamps"
+  fail=1
+fi
 
-  # No bare #N (reference upstream as mihonapp/mihon#N; owner/repo#N is fine).
-  hn=$(printf '%s\n' "$sync" | grep -nE '(^|[^A-Za-z0-9])#[0-9]' || true)
-  if [ -n "$hn" ]; then
-    echo "upstream-sync: bare '#N' auto-links to a Reikai issue, use mihonapp/mihon#N:"
-    echo "$hn"
-    fail=1
+# ===== docs/dev/off-path-manifest.md: a deleted Mihon file must stay deleted and stay declared =====
+# The manifest only works if every row is real and no listed file comes back. Both failures used to be
+# silent: a resurrected file gives two implementations of one surface, and a reroute with no row means
+# the next sync never learns upstream touched it.
+manifest="docs/dev/off-path-manifest.md"
+if [ -f "$manifest" ]; then
+  # Every row still describes reality: the file stays deleted and the replacement exists. Shared
+  # with CI, which runs the same check on every push.
+  lint manifest-rows "$manifest"
+
+  # A staged deletion of a file Mihon still has needs a manifest row in the SAME commit, or the reroute
+  # is invisible to every future sync. Needs the refs clone; warn (never block) when it is absent.
+  mihon_clone="../refs/mihon"
+  if [ -d "$mihon_clone" ]; then
+    deleted=$(git diff --cached --name-only --diff-filter=D)
+    for path in $deleted; do
+      git -C "$mihon_clone" cat-file -e "HEAD:$path" 2>/dev/null || continue
+      if ! grep -qF "| $path |" "$manifest"; then
+        echo "off-path manifest: deleting '$path', which Mihon still has, without a manifest row."
+        echo "  Add a row (path | mihon | replacement) so the next sync is told when upstream changes it."
+        fail=1
+      fi
+    done
+  elif [ -n "$(git diff --cached --name-only --diff-filter=D)" ]; then
+    echo "off-path manifest: no refs/mihon clone, skipping the undeclared-reroute check."
   fi
+fi
+
+# ===== comment blocks (.kt under reikai/ or exh/): no wall of text =====
+# See .claude/rules/code-quality.md "Comments". A run of consecutive comment lines is capped at 8, and
+# a 9th line is rejected. Over the cap the invariant stays in the code as a sentence or two and the
+# narrative moves to the feature's record in docs/dev/plans/.
+#
+# Scoped to the Reikai-owned trees. Mihon's own files keep upstream shape, which measures at 97% of
+# comment blocks within the same 8 lines, so this codifies the surrounding style rather than departing
+# from it.
+#
+# The whole staged file is measured, not just its added lines: a comment block is contiguous, so a
+# diff shows fragments of one and a wall added over two commits would slip through.
+#
+# A KDoc tag list (@param, @return, @property, ...) stops the count for the rest of its block. Tags
+# are an enumeration keyed to the signature, not narrative, so a function with six documented
+# parameters is not the wall this cap is aimed at. Tags always come last in a KDoc, so the prose
+# above them is still measured in full.
+blocks=""
+for f in $(git diff --cached --name-only --diff-filter=ACM -- '*.kt' | grep -E '(^|/)(reikai|exh)/' || true); do
+  blocks="$blocks$(git show ":$f" | awk -v file="$f" '
+    { line = $0; sub(/^[ \t]+/, "", line); isc = 0
+      if (inblock)               { isc = 1; if (line ~ /\*\//) inblock = 0 }
+      else if (line ~ /^\/\*/)   { isc = 1; if (line !~ /\*\//) inblock = 1; tagged = 0 }
+      else if (line ~ /^\/\//)   { isc = 1 }
+      if (isc && line ~ /^\*[ \t]*@/) tagged = 1
+      if (isc && !tagged) { if (run == 0) start = NR; run++ }
+      else { if (run > 8) print file ":" start ": " run " lines"; run = 0 }
+      if (!isc) tagged = 0 }
+    END      { if (run > 8) print file ":" start ": " run " lines" }
+  ')
+"
+done
+over_cap=$(printf '%s' "$blocks" | grep -E ': [0-9]+ lines$' || true)
+if [ -n "$over_cap" ]; then
+  echo "code comments: a comment block runs past the cap of 8 lines."
+  echo "Keep the invariant, the trap or the coupling in the code as a sentence or two; move the"
+  echo "narrative to the feature's record in docs/dev/plans/ and point at it by filename:"
+  echo "$over_cap"
+  fail=1
 fi
 
 if [ "$fail" -ne 0 ]; then

--- a/.github/ISSUE_TEMPLATE/2_report_issue.yml
+++ b/.github/ISSUE_TEMPLATE/2_report_issue.yml
@@ -102,7 +102,7 @@ body:
           required: true
         - label: I have written a short but informative title.
           required: true
-        - label: I have gone through the [FAQ](https://mihon.app/docs/faq/general) and [troubleshooting guide](https://mihon.app/docs/guides/troubleshooting/).
+        - label: I have gone through the [FAQ](https://reikai.app/docs/faq/general) and [troubleshooting guide](https://reikai.app/docs/guides/troubleshooting/).
           required: true
         - label: I have updated the app to the [latest release](https://github.com/unseensnick/Reikai/releases/latest).
           required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -7,8 +7,8 @@ contact_links:
     url: https://github.com/unseensnick/Reikai/discussions/new?category=q-a
     about: Ask in Q&A. Check the pinned FAQ first.
   - name: ❌ Help with Extensions
-    url: https://mihon.app/docs/faq/browse/extensions
+    url: https://reikai.app/docs/faq/browse/extensions
     about: For third-party extension questions/issues (out of scope here).
-  - name: 📖 Documentation (Mihon)
-    url: https://mihon.app/
-    about: Reikai is built on Mihon, so its guides, troubleshooting, and FAQ mostly apply.
+  - name: 📖 Documentation
+    url: https://reikai.app/
+    about: Guides, troubleshooting and the FAQ, including the parts inherited from Mihon.

--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -1,0 +1,34 @@
+name: Set up the Gradle build
+description: >
+  JDK, Gradle and the runner's Gradle properties, shared by every workflow that runs ./gradlew.
+  Checkout is NOT included: GitHub can only resolve a local action once the repo is on disk, so
+  each caller checks out first and then uses this.
+
+inputs:
+  cache-read-only:
+    description: >
+      Leave true to read the Gradle cache without writing it. Set false on a workflow that runs
+      from a long-lived branch, so that branch keeps its own dependencies and build-cache entries
+      warm instead of restoring whatever the default branch last wrote.
+    required: false
+    default: 'true'
+
+runs:
+  using: composite
+  steps:
+    - name: Set up JDK
+      uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
+      with:
+        java-version-file: .github/.java-version
+        distribution: temurin
+
+    - name: Set up Gradle
+      uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+      with:
+        cache-read-only: ${{ inputs.cache-read-only }}
+
+    - name: Copy CI gradle.properties
+      shell: bash
+      run: |
+        mkdir -p ~/.gradle
+        cp .github/runner-files/ci-gradle.properties ~/.gradle/gradle.properties

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -34,23 +34,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Android SDK
-        run: |
-          ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager "build-tools;35.0.0"
-
-      - name: Set up JDK
-        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
-        with:
-          java-version-file: .github/.java-version
-          distribution: temurin
-
-      - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
-
-      - name: Copy CI gradle.properties
-        run: |
-          mkdir -p ~/.gradle
-          cp .github/runner-files/ci-gradle.properties ~/.gradle/gradle.properties
+      - name: Set up the build
+        uses: ./.github/actions/setup-build
 
       # Fail fast on formatting before the expensive build (matches Mihon's CI).
       - name: Check formatting

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -23,6 +23,12 @@ on:
       - 'i18n/src/commonMain/moko-resources/base/strings.xml'
       - 'i18n/src/commonMain/moko-resources/base/plurals.xml'
 
+# The junit-report action writes a check run, which the default token cannot do. Without this the
+# step logs "Resource not accessible by integration" and publishes nothing, without failing the job.
+permissions:
+  contents: read
+  checks: write
+
 jobs:
   build:
     name: Build app
@@ -37,14 +43,19 @@ jobs:
       - name: Set up the build
         uses: ./.github/actions/setup-build
 
+      - name: Dependency review
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+
       # Fail fast on formatting before the expensive build (matches Mihon's CI).
       - name: Check formatting
         run: ./gradlew spotlessCheck
 
-      # Mihon base has no product flavors; the variant is just `release` (debug-signed for now).
-      - name: Build the app
-        run: ./gradlew assembleRelease
+      # A schema change shipped without its .sqm is invisible until an upgraded install crashes on a
+      # missing table, and this is the only thing that catches it.
+      - name: Verify SQLDelight migrations
+        run: ./gradlew verifySqlDelightMigration
 
+      # Tests before the build: a failing test should not cost a full minified build first.
       - name: Run unit tests
         run: ./gradlew test
 
@@ -55,6 +66,10 @@ jobs:
           include_passed: true
           detailed_summary: true
           report_paths: '**/build/test-results/test*/TEST-*.xml'
+
+      # Mihon base has no product flavors; the variant is just `release` (debug-signed for now).
+      - name: Build the app
+        run: ./gradlew assembleRelease
 
       - name: Upload APK to artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -43,9 +43,6 @@ jobs:
       - name: Set up the build
         uses: ./.github/actions/setup-build
 
-      - name: Dependency review
-        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
-
       # Fail fast on formatting before the expensive build (matches Mihon's CI).
       - name: Check formatting
         run: ./gradlew spotlessCheck

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Build & publish release
 
 # Stable channel. Signs with the repo keystore secrets (AGP-native, see app/build.gradle.kts),
 # publishes to this repo as a DRAFT for review; the in-app updater sees it once you publish.
-# Preview/nightly builds are handled separately by preview.yml.
+# Nightly builds are handled separately by nightly.yml.
 
 on:
   push:
@@ -36,22 +36,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up JDK
-        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
-        with:
-          java-version-file: .github/.java-version
-          distribution: temurin
-
-      - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
-
-      - name: Setup Android SDK
-        run: ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager "build-tools;35.0.0"
-
-      - name: Copy CI gradle.properties
-        run: |
-          mkdir -p ~/.gradle
-          cp .github/runner-files/ci-gradle.properties ~/.gradle/gradle.properties
+      - name: Set up the build
+        uses: ./.github/actions/setup-build
 
       - name: Resolve version tag
         run: |
@@ -65,8 +51,13 @@ jobs:
       - name: Run unit tests
         run: ./gradlew test
 
+      - name: Write the Firebase config
+        env:
+          GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
+        run: bash scripts/ci/write-firebase-config.sh
+
       - name: Build signed release APKs
-        run: ./gradlew assembleRelease -Penable-updater
+        run: ./gradlew assembleRelease -Pinclude-telemetry -Penable-updater
         env:
           REIKAI_GITHUB_RELEASE: "true"
           storeFileBase64: ${{ secrets.SIGNING_KEY }}
@@ -74,67 +65,40 @@ jobs:
           keyAlias: ${{ secrets.ALIAS }}
           keyPassword: ${{ secrets.KEY_PASSWORD }}
 
-      # Stable builds ship to users, so keep their R8 mapping to deobfuscate crash stacks.
+      # The FOSS build is the Firebase-free alternative, so it is a second Gradle run WITHOUT
+      # -Pinclude-telemetry (telemetry inclusion is a whole-build property, not a per-variant one).
+      # Universal only, and the name must keep "-foss" for the in-app updater to match it.
+      - name: Build signed FOSS APK
+        run: ./gradlew assembleFoss -Penable-updater
+        env:
+          REIKAI_GITHUB_RELEASE: "true"
+          storeFileBase64: ${{ secrets.SIGNING_KEY }}
+          storePassword: ${{ secrets.KEY_STORE_PASSWORD }}
+          keyAlias: ${{ secrets.ALIAS }}
+          keyPassword: ${{ secrets.KEY_PASSWORD }}
+
+      # Stable builds ship to users, so keep their R8 mapping to deobfuscate crash stacks. FOSS
+      # sends no crash reports at all, so its mapping is the only way to read a pasted stack.
       - name: Upload R8 mapping
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: mapping-${{ env.VERSION_TAG }}
-          path: app/build/outputs/mapping/release
+          path: |
+            app/build/outputs/mapping/release
+            app/build/outputs/mapping/foss
 
       - name: Install parse-changelog
         uses: taiki-e/install-action@parse-changelog
 
       - name: Prepare release body
         env:
+          VERSION_TAG: ${{ env.VERSION_TAG }}
+          REPO_URL: ${{ github.server_url }}/${{ github.repository }}
           MESSAGE: ${{ github.event.inputs.message }}
-        run: |
-          set -e
-          version="${VERSION_TAG#v}"
-          # Stable notes come ONLY from the matching [version] section (cut by renaming [Unreleased] to
-          # [version]). No [Unreleased] fallback, or preview-only changes would leak into a stable release.
-          if ! changelog="$(parse-changelog CHANGELOG.md "$version" 2>/dev/null)"; then
-            echo "::error::CHANGELOG.md has no [$version] section. Rename [Unreleased] to [$version] (and add a fresh empty [Unreleased]) before cutting v$version."
-            exit 1
-          fi
-          # The release note is the one-line bold headline of each entry (kept scannable, like
-          # Mihon / LNReader); the full sentences stay in CHANGELOG.md, linked below. The sed reduces
-          # "- **Headline.** detail" -> "- Headline." and a "**Sub-header**" line -> "#### Sub-header".
-          highlights="$(printf '%s\n' "$changelog" \
-            | sed -E -e 's/^- \*\*([^*]+)\*\*.*/- \1/' -e 's/^\*\*([^*]+)\*\*$/#### \1/')"
-          # Previous tag (linear main), for a "changes since" compare link. Empty on the first release.
-          prev="$(git describe --tags --abbrev=0 "${VERSION_TAG}^" 2>/dev/null || true)"
-          repo="${{ github.server_url }}/${{ github.repository }}"
-          {
-            echo "RELEASE_BODY<<__EOF__"
-            if [ -n "$MESSAGE" ]; then
-              printf '%s\n\n' "$MESSAGE"
-            fi
-            printf '%s\n\n' "$highlights"
-            printf '**Full changelog:** %s/blob/main/CHANGELOG.md\n' "$repo"
-            if [ -n "$prev" ]; then
-              printf '**Changes since %s:** %s/compare/%s...%s\n' "$prev" "$repo" "$prev" "$VERSION_TAG"
-            fi
-            echo "__EOF__"
-          } >> "$GITHUB_ENV"
+        run: bash scripts/ci/release-notes.sh
 
       - name: Rename APKs and checksum
-        run: |
-          set -e
-          d=app/build/outputs/apk/release
-          declare -A abis=( [universal]="" [arm64-v8a]="-arm64-v8a" [armeabi-v7a]="-armeabi-v7a" [x86]="-x86" [x86_64]="-x86_64" )
-          checksums="### Checksums"$'\n\n'"| Variant | SHA-256 |"$'\n'"| ------- | ------- |"
-          for key in universal arm64-v8a armeabi-v7a x86 x86_64; do
-            src="$d/app-${key}-release.apk"
-            out="reikai${abis[$key]}-${VERSION_TAG}.apk"
-            mv "$src" "$out"
-            sum=$(sha256sum "$out" | awk '{ print $1 }')
-            checksums+=$'\n'"| \`$out\` | \`$sum\` |"
-          done
-          {
-            echo "CHECKSUMS<<__EOF__"
-            echo "$checksums"
-            echo "__EOF__"
-          } >> "$GITHUB_ENV"
+        run: bash scripts/ci/package-apks.sh release "${VERSION_TAG}"
 
       - name: Create draft release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
@@ -148,15 +112,20 @@ jobs:
 
             <!-->
 
-            ${{ env.CHECKSUMS }}
+            ### Which file?
 
-            > If you are unsure which to download, use `reikai-${{ env.VERSION_TAG }}.apk` (universal).
+            - `reikai-${{ env.VERSION_TAG }}.apk` if you are unsure. Universal, runs on any device.
+            - `reikai-arm64-v8a-${{ env.VERSION_TAG }}.apk` and the other ABI files are smaller downloads for one CPU type. Most modern phones are `arm64-v8a`.
+            - `reikai-foss-${{ env.VERSION_TAG }}.apk` has no crash reporting or analytics compiled in. It installs as a separate app, so moving to or from it needs a backup and restore.
+
+            ${{ env.CHECKSUMS }}
           files: |
             reikai-${{ env.VERSION_TAG }}.apk
             reikai-arm64-v8a-${{ env.VERSION_TAG }}.apk
             reikai-armeabi-v7a-${{ env.VERSION_TAG }}.apk
             reikai-x86-${{ env.VERSION_TAG }}.apk
             reikai-x86_64-${{ env.VERSION_TAG }}.apk
+            reikai-foss-${{ env.VERSION_TAG }}.apk
           draft: true
           prerelease: false
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@ Reikai uses its own [Semantic Versioning](https://semver.org/) from the Mihon-ba
 
 ## [Unreleased]
 
+## [0.3.2]
+
+### Changes
+
+- **This release cannot update your current Reikai, so it installs alongside it and you will need to move your library across.** Reikai had been identifying itself to Android as Tachiyomi; it now uses its own identifier, and Android treats that as a different app.
+
+**Moving your library across**
+
+- **Back up first from Settings > Data and storage > Backup and restore > Create backup, ticking "Include sensitive settings" so your tracker logins come with it.** Everything else in the backup is included by default.
+- **Install this release, then choose the same storage folder when it asks.** Your downloads, local source files and old backups are all in there, and it finds them again once you point at it.
+- **Restore that backup, then uninstall the old Reikai.** Left installed, it will keep offering updates it can no longer install.
+- **Covers you set by hand are the one thing a backup cannot bring across.** They live inside the old app and are removed with it, so set those again afterwards.
+
 ## [0.3.1]
 
 ### Additions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,7 @@ EVERY commit on the branch (including `docs` / `chore` / one-line fixes, not jus
 
 ## Identity (load-bearing, preserve through the rebase)
 
-`applicationId = "eu.kanade.tachiyomi"` with release suffix `.y2k` (and debug `.debugY2k`), so existing installs upgrade in place. Mihon's own `applicationId` is `app.mihon`; the namespace `eu.kanade.tachiyomi` is shared by both, so source classes resolve either way. App name string `Reikai` lives in `i18n/src/commonMain/moko-resources/base/strings.xml`. Keep the `.y2k` suffix and app name; take Mihon for everything else.
+`applicationId = "app.reikai"`, with upstream's suffixes on top of it: `.dev` for debug, `.debug` for preview, `.foss`, `.benchmark`, and none at all on release. The **namespace** stays `eu.kanade.tachiyomi`, which Mihon shares, so source classes and installed extensions resolve either way. App name string `Reikai` lives in `i18n/src/commonMain/moko-resources/base/strings.xml`. Renamed at 0.3.2 from `eu.kanade.tachiyomi` + `.y2k`, which was Tachiyomi's id rather than the fork's own; because Android identifies an app by that id, 0.3.2 installs beside an older build instead of over it. Keep the id and app name; take Mihon for everything else.
 
 **Reikai patches on Mihon files** are fenced with `// RK -->` / `// RK <--` comment islands (grep `// RK` to find every active patch), mirroring how Komikku marks its `// SY` / `// KMK` patches. Everything that can live in its own file/module should, rather than editing Mihon's files.
 
@@ -82,7 +82,7 @@ EVERY commit on the branch (including `docs` / `chore` / one-line fixes, not jus
 
 Build in Android Studio. Gradle: JDK 21 (Temurin 21.0.11; matches `.github/.java-version`), formatting via Spotless (`./gradlew spotlessApply`), version catalogs `libs` and `mihonx`, build-logic via `gradle/build-logic` (`includeBuild`). Domain tests: `./gradlew :domain:test`. No `lintKotlin` / `formatKotlin` tasks exist (Kotlinter only installs a pre-push hook); use `spotlessApply` to format and `compileDebugKotlin` to check. (CLI Gradle is intermittent on this machine; build/test on-device in Android Studio when CLI fails.)
 
-**Release-type builds are minified, the `debugY2k` dev build is not**, so R8-only bugs are invisible in the normal dev loop. The recurring one: a net-new top-level package that uses Injekt generics (`Injekt.get<T>()`) needs its own proguard `-keep`, or the minified build crashes (Injekt `FullTypeReference`). When adding such a package or code, add the keep and verify a minified `:app:assemblePreview` build. Full rule: [.claude/rules/architecture.md](.claude/rules/architecture.md) "Minification (R8) and net-new packages".
+**Release-type builds are minified, the `debug` dev build is not**, so R8-only bugs are invisible in the normal dev loop. The recurring one: a net-new top-level package that uses Injekt generics (`Injekt.get<T>()`) needs its own proguard `-keep`, or the minified build crashes (Injekt `FullTypeReference`). When adding such a package or code, add the keep and verify a minified `:app:assemblePreview` build. Full rule: [.claude/rules/architecture.md](.claude/rules/architecture.md) "Minification (R8) and net-new packages".
 
 ## Current release target (0.3.0, cut)
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Two things set it apart from the lineage: **manga and light novels share one lib
 
 It is built first for my own daily use, so development is sporadic and the feature set follows my taste rather than a broad roadmap. It rides Mihon's actively maintained base for the core reader and layers these features on top.
 
-**New here? Start with the [FAQ](docs/FAQ.md)**: what Reikai is, how updates work, where to download safely, and how sources behave.
+**New here? Start at [reikai.app](https://reikai.app)**: what Reikai is, how updates work, where to download safely, and how sources behave.
 
 ## Features
 
@@ -36,14 +36,14 @@ It is built first for my own daily use, so development is sporadic and the featu
 
 ### Reikai's own features
 
-- `Multi-source grouping` (manga + novels): fold same-title entries from different sources into one card, with a per-source switcher. ([docs](docs/multi-source.md))
-- `Manual merge / unmerge`: group entries by hand when titles differ, or split a group apart. ([docs](docs/multi-source.md))
-- `Merge-aware reading`: read a merged series through every source, one unified chapter list. ([docs](docs/multi-source.md#reading-a-merged-group))
-- `Tracker sync` across grouped sources: a tracker on one source is shared across the group. ([docs](docs/tracker-sync.md))
-- `Category sort order` + `bulk delete`: order categories, and multi-delete with undo. ([docs](docs/categories.md))
+- `Multi-source grouping` (manga + novels): fold same-title entries from different sources into one card, with a per-source switcher. ([docs](https://reikai.app/docs/multi-source))
+- `Manual merge / unmerge`: group entries by hand when titles differ, or split a group apart. ([docs](https://reikai.app/docs/multi-source))
+- `Merge-aware reading`: read a merged series through every source, one unified chapter list. ([docs](https://reikai.app/docs/multi-source#reading-a-group))
+- `Tracker sync` across grouped sources: a tracker on one source is shared across the group. ([docs](https://reikai.app/docs/guides/tracking))
+- `Category sort order` + `bulk delete`: order categories, and multi-delete with undo. ([docs](https://reikai.app/docs/guides/categories))
 - `Light novels`, first-class: a full Novels library equal to manga; sources + reader from [LNReader](https://github.com/LNReader/lnreader) on a headless QuickJS host; and track novels on AniList, MyAnimeList, MangaUpdates, Kitsu, Shikimori, Hikka and MangaBaka.
-- `Taste-profile recommendations`: rank the related row by your tracked-tag preferences. ([docs](docs/related-mangas.md#taste-profile))
-- `Cloudflare bypass` support: route a blocked source through a self-hosted proxy ([Solverr](https://github.com/unseensnick/Solverr) recommended, or Byparr / FlareSolverr). ([docs](docs/flaresolverr.md))
+- `Taste-profile recommendations`: rank the related row by your tracked-tag preferences. ([docs](https://reikai.app/docs/related-mangas#your-taste-profile))
+- `Cloudflare bypass` support: route a blocked source through a self-hosted proxy ([Solverr](https://github.com/unseensnick/Solverr) recommended, or Byparr / FlareSolverr). ([docs](https://reikai.app/docs/flaresolverr))
 - `Library update errors`: an opt-in list of entries that failed their last update.
 
 <details>
@@ -62,11 +62,11 @@ Carried over from [Yōkai](https://github.com/null2264/yokai) (Reikai's previous
 
 Ported from [Komikku](https://github.com/komikku-app/komikku) (a Mihon fork), re-typed onto Mihon and extended:
 
-- `Related-mangas carousel`: similar titles below the description, with Reikai's taste layer above them. ([docs](docs/related-mangas.md))
-- `Adult content sources`: built-in sources, browse, tag search, metadata, account settings and backup. Off by default. ([docs](docs/adult-sources.md))
+- `Related-mangas carousel`: similar titles below the description, with Reikai's taste layer above them. ([docs](https://reikai.app/docs/related-mangas))
+- `Adult content sources`: built-in sources, browse, tag search, metadata, account settings and backup. Off by default. ([docs](https://reikai.app/docs/adult-sources))
 - `Enhanced source support`: sign in to one of the most-used manga sources for source-native details, follows browse, two-way library sync, and its built-in `MDList` tracker.
 - `Edit info` (manga + novels): edit an entry's title, author, cover, description, tags and status, with `Fill from tracker` to autofill them. Reikai unifies it across both types and keeps the source's own values intact.
-- `Auto webtoon mode`: manhwa, manhua and webtoons open in webtoon mode on their own, going by tags and source name. Off by default. ([FAQ](docs/FAQ.md))
+- `Auto webtoon mode`: manhwa, manhua and webtoons open in webtoon mode on their own, going by tags and source name. Off by default. ([FAQ](https://reikai.app/docs/faq/reader#i-turned-on-auto-webtoon-mode-but-a-manhwa-still-opens-paged-why))
 
 </details>
 
@@ -94,7 +94,7 @@ The core manga experience is Mihon's (Tachiyomi lineage):
 
 This is a personal fork: pull requests are welcome, but a PR may take a while and might not be merged if it doesn't fit the fork's direction. For anything beyond a small fix, raise it first.
 
-**New here? Start with the [FAQ](docs/FAQ.md).** Still stuck? Ask in [Q&A](https://github.com/unseensnick/Reikai/discussions/categories/q-a).
+**New here? Start at [reikai.app](https://reikai.app).** Still stuck? Ask in [Q&A](https://github.com/unseensnick/Reikai/discussions/categories/q-a).
 
 <details><summary><strong>Bugs</strong></summary>
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -34,13 +34,16 @@ android {
     namespace = "eu.kanade.tachiyomi"
 
     defaultConfig {
-        // RK --> Reikai identity: keep eu.kanade.tachiyomi base + .y2k suffix so existing installs upgrade in place.
-        // versionName: Reikai's own SemVer for the Mihon era, starting at 0.1.0 (drops the old 5-segment Yokai scheme).
-        // versionCode must keep climbing and stay above the last Yokai-based build (168) so installs upgrade in place.
-        applicationId = "eu.kanade.tachiyomi"
+        // RK --> Reikai identity. app.reikai is the fork's own id, named the way the other Mihon
+        // forks name theirs; the namespace above stays eu.kanade.tachiyomi, which upstream shares, so
+        // source classes and installed extensions still resolve. Android treats this as a different
+        // app from eu.kanade.tachiyomi.y2k, so it installs beside an older build instead of over it;
+        // the release notes carry the backup-and-restore steps. versionCode still only ever climbs,
+        // so later releases upgrade this one in place.
+        applicationId = "app.reikai"
 
-        versionCode = 184
-        versionName = "0.3.1"
+        versionCode = 185
+        versionName = "0.3.2"
         // RK <--
 
         buildConfigField("String", "COMMIT_COUNT", "\"${getLatestCommitCount()}\"")
@@ -84,7 +87,7 @@ android {
 
     buildTypes {
         val debug = getByName("debug") {
-            applicationIdSuffix = ".debugY2k" // RK: match existing Reikai debug package
+            applicationIdSuffix = ".dev" // RK: matches upstream, so this block stays diffable
             versionNameSuffix = "-${getLatestCommitCount()}"
             isPseudoLocalesEnabled = true
         }
@@ -92,9 +95,9 @@ android {
             isMinifyEnabled = true
             isShrinkResources = true
 
-            // RK --> existing Reikai release package; signed with the real key when CI secrets or a
-            // local keystore.properties are present (see the signingConfigs block above), else debug-signed.
-            applicationIdSuffix = ".y2k"
+            // RK --> signed with the real key when CI secrets or a local keystore.properties are
+            // present (see the signingConfigs block above), else debug-signed. The release variant
+            // carries no applicationIdSuffix, so it ships as plain app.reikai, matching upstream.
             signingConfig = signingConfigs.getByName("debug")
             // RK <--
 

--- a/app/src/main/java/eu/kanade/presentation/more/onboarding/GuidesStep.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/onboarding/GuidesStep.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import eu.kanade.presentation.theme.TachiyomiPreviewTheme
+import tachiyomi.core.common.Constants
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.components.material.padding
 import tachiyomi.presentation.core.i18n.stringResource
@@ -56,7 +57,7 @@ internal class GuidesStep(
     }
 }
 
-const val GETTING_STARTED_URL = "https://mihon.app/docs/guides/getting-started"
+const val GETTING_STARTED_URL = "${Constants.URL_DOCS}/guides/getting-started" // RK: Reikai's docs
 
 @PreviewLightDark
 @Composable

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDataScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDataScreen.kt
@@ -60,6 +60,7 @@ import eu.kanade.tachiyomi.util.system.toast
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import logcat.LogPriority
+import tachiyomi.core.common.Constants
 import tachiyomi.core.common.i18n.stringResource
 import tachiyomi.core.common.storage.displayablePath
 import tachiyomi.core.common.util.lang.launchNonCancellable
@@ -80,7 +81,7 @@ import uy.kohesive.injekt.api.get
 object SettingsDataScreen : SearchableSettings {
 
     val restorePreferenceKeyString = MR.strings.label_backup
-    const val HELP_URL = "https://mihon.app/docs/faq/storage"
+    const val HELP_URL = "${Constants.URL_DOCS}/faq/storage" // RK: Reikai's docs
 
     @ReadOnlyComposable
     @Composable

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsTrackingScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsTrackingScreen.kt
@@ -60,6 +60,7 @@ import eu.kanade.tachiyomi.util.system.toast
 import exh.md.utils.MdConstants
 import exh.md.utils.MdUtil
 import reikai.domain.library.ReikaiLibraryPreferences
+import tachiyomi.core.common.Constants
 import tachiyomi.core.common.util.lang.launchIO
 import tachiyomi.core.common.util.lang.withUIContext
 import tachiyomi.domain.source.service.SourceManager
@@ -78,7 +79,7 @@ object SettingsTrackingScreen : SearchableSettings {
     @Composable
     override fun RowScope.AppBarAction() {
         val uriHandler = LocalUriHandler.current
-        IconButton(onClick = { uriHandler.openUri("https://mihon.app/docs/guides/tracking") }) {
+        IconButton(onClick = { uriHandler.openUri("${Constants.URL_DOCS}/guides/tracking") }) {
             Icon(
                 imageVector = Icons.AutoMirrored.Outlined.HelpOutline,
                 contentDescription = stringResource(MR.strings.tracking_guide),

--- a/app/src/main/java/eu/kanade/presentation/webview/WebViewScreenContent.kt
+++ b/app/src/main/java/eu/kanade/presentation/webview/WebViewScreenContent.kt
@@ -52,6 +52,7 @@ import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.util.system.getHtml
 import eu.kanade.tachiyomi.util.system.setDefaultSettings
 import kotlinx.coroutines.launch
+import tachiyomi.core.common.Constants
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.components.material.Scaffold
 import tachiyomi.presentation.core.i18n.stringResource
@@ -296,7 +297,7 @@ fun WebViewScreenContent(
                                     .clip(MaterialTheme.shapes.small)
                                     .clickable {
                                         uriHandler.openUri(
-                                            "https://mihon.app/docs/guides/troubleshooting/#cloudflare",
+                                            "${Constants.URL_DOCS}/guides/troubleshooting/#cloudflare",
                                         )
                                     },
                             )

--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
@@ -43,6 +43,7 @@ import mihon.domain.source.interactor.UpdateMangaFromRemote
 import reikai.domain.library.ReikaiLibraryPreferences
 import reikai.domain.library.updateerror.DeleteLibraryUpdateErrors
 import reikai.domain.library.updateerror.UpsertLibraryUpdateError
+import tachiyomi.core.common.Constants
 import tachiyomi.core.common.i18n.stringResource
 import tachiyomi.core.common.preference.getAndSet
 import tachiyomi.core.common.util.lang.withIOContext
@@ -435,7 +436,7 @@ class LibraryUpdateJob(private val context: Context, workerParams: WorkerParamet
         private const val WORK_NAME_AUTO = "LibraryUpdate-auto"
         private const val WORK_NAME_MANUAL = "LibraryUpdate-manual"
 
-        private const val ERROR_LOG_HELP_URL = "https://mihon.app/docs/guides/troubleshooting/"
+        private const val ERROR_LOG_HELP_URL = Constants.URL_HELP // RK: Reikai's docs
 
         private const val MANGA_PER_SOURCE_QUEUE_WARNING_THRESHOLD = 60
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateNotifier.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateNotifier.kt
@@ -402,7 +402,7 @@ class LibraryUpdateNotifier(
 
     companion object {
         const val HELP_WARNING_URL =
-            "https://mihon.app/docs/faq/library#why-am-i-warned-about-large-bulk-updates-and-downloads"
+            "${Constants.URL_DOCS}/faq/library#why-am-i-being-warned-about-bulk-updates-and-downloads"
     }
 }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/sources/MigrateSourceTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/sources/MigrateSourceTab.kt
@@ -14,6 +14,7 @@ import eu.kanade.presentation.browse.MigrateSourceScreen
 import eu.kanade.presentation.components.AppBar
 import eu.kanade.presentation.components.TabContent
 import eu.kanade.tachiyomi.ui.browse.migration.manga.MigrateMangaScreen
+import tachiyomi.core.common.Constants
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.i18n.stringResource
 
@@ -31,7 +32,7 @@ fun Screen.migrateSourceTab(): TabContent {
                 title = stringResource(MR.strings.migration_help_guide),
                 icon = Icons.AutoMirrored.Outlined.HelpOutline,
                 onClick = {
-                    uriHandler.openUri("https://mihon.app/docs/guides/source-migration")
+                    uriHandler.openUri("${Constants.URL_DOCS}/guides/source-migration")
                 },
             ),
         ),

--- a/app/src/main/java/reikai/presentation/browse/migrate/ReikaiMigrateSourceTab.kt
+++ b/app/src/main/java/reikai/presentation/browse/migrate/ReikaiMigrateSourceTab.kt
@@ -39,6 +39,7 @@ import reikai.presentation.browse.ReikaiBrowseScreenModel
 import reikai.presentation.browse.components.BrowseSectionHeader
 import reikai.presentation.browse.components.NovelSourceRow
 import reikai.presentation.components.ContentTypeFilterChips
+import tachiyomi.core.common.Constants
 import tachiyomi.domain.source.model.Source
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.components.Badge
@@ -76,7 +77,7 @@ fun Screen.reikaiMigrateSourceTab(browseScreenModel: ReikaiBrowseScreenModel): T
             AppBar.Action(
                 title = stringResource(MR.strings.migration_help_guide),
                 icon = Icons.AutoMirrored.Outlined.HelpOutline,
-                onClick = { uriHandler.openUri("https://mihon.app/docs/guides/source-migration") },
+                onClick = { uriHandler.openUri("${Constants.URL_DOCS}/guides/source-migration") },
             ),
         ),
         content = { contentPadding, _ ->

--- a/core/common/src/main/kotlin/tachiyomi/core/common/Constants.kt
+++ b/core/common/src/main/kotlin/tachiyomi/core/common/Constants.kt
@@ -1,8 +1,16 @@
 package tachiyomi.core.common
 
 object Constants {
-    const val URL_HELP = "https://mihon.app/docs/guides/troubleshooting/"
-    const val URL_HELP_UPCOMING = "https://mihon.app/docs/faq/updates/upcoming"
+    // RK -->
+    // Every user-facing doc link in the app builds from this, so the host is written once. Help URLs
+    // ship inside released APKs and outlive them, so a stale one cannot be recalled.
+    const val URL_SITE = "https://reikai.app"
+    const val URL_DOCS = "$URL_SITE/docs"
+
+    const val URL_HELP = "$URL_DOCS/guides/troubleshooting/"
+    const val URL_HELP_UPCOMING = "$URL_DOCS/faq/updates/upcoming"
+
+    // RK <--
     const val URL_DONATE_PATREON = "https://patreon.com/mihon/membership"
     const val URL_DONATE_OPENCOLLECTIVE = "https://opencollective.com/mihon/contribute"
     const val URL_DISCORD = "https://discord.gg/mihon"

--- a/docs/dev/development.md
+++ b/docs/dev/development.md
@@ -6,7 +6,7 @@
 
 - GitHub: `https://github.com/unseensnick/Reikai`
 - Mihon upstream: `https://github.com/mihonapp/mihon`
-- Package ID: `eu.kanade.tachiyomi`, release suffix `.y2k` (debug `.debugY2k`). Legacy, kept so existing installs upgrade in place. Mihon's own applicationId is `app.mihon`; the `eu.kanade.tachiyomi` namespace is shared by both, so source classes resolve either way.
+- Package ID: `app.reikai`, with no suffix on release and upstream's suffixes elsewhere (`.dev` debug, `.debug` preview, `.foss`, `.benchmark`). Renamed at 0.3.2 from `eu.kanade.tachiyomi` + `.y2k`. The `eu.kanade.tachiyomi` **namespace** is unchanged and shared with Mihon, so source classes and installed extensions resolve either way.
 - App name string: `Reikai` (`i18n/src/commonMain/moko-resources/base/strings.xml`).
 - Backups are **not** interchangeable with the old Yōkai-based builds: Mihon's database schema differs, so a Mihon-based install cannot open a Yōkai-Reikai database.
 
@@ -27,7 +27,7 @@ The working rules under `.claude/rules/` are the single source of truth; this do
 
 - Android Studio (`Build → Make/Rebuild`). JDK 21 (Temurin 21.0.11; matches `.github/.java-version`). Formatting via Spotless (`./gradlew spotlessApply`).
 - `minSdk 26`, `targetSdk 36`, `compileSdk 37`.
-- No product flavors. Build types: `debug` (`.debugY2k`), `release` (`.y2k`), `foss`, `preview`, `benchmark`. Release builds use AGP-native signing with the real key when CI secrets or a local `keystore.properties` are present, else they fall back to debug-signed (see the `// RK` signing block in `app/build.gradle.kts`). The `preview` build type doubles as the nightly channel.
+- No product flavors. Build types: `debug` (`.dev`), `release` (no suffix), `foss`, `preview` (`.debug`), `benchmark`. Release builds use AGP-native signing with the real key when CI secrets or a local `keystore.properties` are present, else they fall back to debug-signed (see the `// RK` signing block in `app/build.gradle.kts`). The `preview` build type doubles as the nightly channel.
 - Domain tests: `./gradlew :domain:test`.
 - CLI Gradle is intermittent on the dev machine (loopback flake); build/test on-device in Android Studio when it fails.
 

--- a/docs/dev/on-device-testing.md
+++ b/docs/dev/on-device-testing.md
@@ -9,9 +9,9 @@ loopback failure for Gradle and mangles `/sdcard`-style paths via MSYS).
 ## 0. Facts you need first
 
 - **adb:** `$env:LOCALAPPDATA\Android\Sdk\platform-tools\adb.exe` (there's a `sqlite3.exe` beside it for DB pulls).
-- **Debug package:** `eu.kanade.tachiyomi.debugY2k` (the instrumented test package is `…debugY2k.test`).
+- **Debug package:** `app.reikai.dev` (the instrumented test package is `app.reikai.dev.test`).
 - **Build + install** (JDK not on PATH, set JAVA_HOME inline): `$env:JAVA_HOME="$HOME\.jdks\temurin-21.0.11"; & ".\gradlew.bat" :app:installDebug --offline --console=plain`. Compile-only: `:app:compileDebugKotlin`.
-- **Confirm the device + that the app is installed:** `& $adb devices` and `& $adb shell pm path eu.kanade.tachiyomi.debugY2k`.
+- **Confirm the device + that the app is installed:** `& $adb devices` and `& $adb shell pm path app.reikai.dev`.
 - **Screen geometry is device-specific.** Get it with `& $adb shell wm size` (the reference Z Fold reports `1856x2160`). You need the real resolution because a screenshot you read back is downscaled, so tap coordinates must be mapped against the REAL resolution (see §2/§3).
 - **Foldables freeze the inner display when folded/asleep.** Always wake first (§1) or `screencap` returns a stale frozen frame and `input` may not land.
 
@@ -22,7 +22,7 @@ Define `$adb` once per command block: `$adb = "$env:LOCALAPPDATA\Android\Sdk\pla
 ```powershell
 $adb = "$env:LOCALAPPDATA\Android\Sdk\platform-tools\adb.exe"
 & $adb shell input keyevent KEYCODE_WAKEUP | Out-Null
-& $adb shell monkey -p eu.kanade.tachiyomi.debugY2k -c android.intent.category.LAUNCHER 1 2>&1 | Out-Null
+& $adb shell monkey -p app.reikai.dev -c android.intent.category.LAUNCHER 1 2>&1 | Out-Null
 ```
 
 `monkey … LAUNCHER 1` reopens the app on its last screen. Installing a fresh APK restarts it.
@@ -136,7 +136,7 @@ Ground-truth via app state (text over stdout, sandbox-safe, no local write):
 
 ```powershell
 $adb = "$env:LOCALAPPDATA\Android\Sdk\platform-tools\adb.exe"
-$pkg = "eu.kanade.tachiyomi.debugY2k"
+$pkg = "app.reikai.dev"
 # a pref actually persisted (e.g. a filter toggle / include-exclude set):
 & $adb shell run-as $pkg cat /data/data/$pkg/shared_prefs/${pkg}_preferences.xml | Select-String 'pref_filter_library_categories'
 # a download actually enqueued (the queue store gains entries; it drains as the job runs):
@@ -203,7 +203,7 @@ $env:JAVA_HOME="$HOME\.jdks\temurin-21.0.11"
 & ".\gradlew.bat" :app:installDebug :app:installDebugAndroidTest --offline --console=plain
 $adb = "$env:LOCALAPPDATA\Android\Sdk\platform-tools\adb.exe"
 & $adb logcat -c
-& $adb shell am instrument -w -e class reikai.novel.host.HeadlessJsIntegrationTest#lnPluginsRunInProductionHeadlessHost eu.kanade.tachiyomi.debugY2k.test/androidx.test.runner.AndroidJUnitRunner
+& $adb shell am instrument -w -e class reikai.novel.host.HeadlessJsIntegrationTest#lnPluginsRunInProductionHeadlessHost app.reikai.dev.test/androidx.test.runner.AndroidJUnitRunner
 & $adb logcat -d -s HeadlessJsTest:I       # the per-plugin breakdown
 ```
 
@@ -232,7 +232,7 @@ No on-device `sqlite3`. Pull the DB binary-safe and query locally. Binary pulls 
 tool (relative remote path; PowerShell `>` corrupts binary), then `sqlite3.exe` locally:
 
 ```bash
-adb exec-out run-as eu.kanade.tachiyomi.debugY2k cat databases/tachiyomi.db > local.db
+adb exec-out run-as app.reikai.dev cat databases/tachiyomi.db > local.db
 # pull the -wal and -shm alongside it (WAL-aware), or VACUUM INTO a single file on-device first
 ```
 

--- a/docs/dev/readme-showcase.md
+++ b/docs/dev/readme-showcase.md
@@ -47,7 +47,7 @@ The screenshots are just the device framebuffer (1344x2992); the frame is compos
 emulator's own skin doesn't matter for the output.
 
 1. **AVD**: 1344x2992, density 480, the `pixel_10_pro_xl` skin. Install the debug app
-   (`eu.kanade.tachiyomi.debugY2k`) and restore a backup so the library/history have content.
+   (`app.reikai.dev`) and restore a backup so the library/history have content.
 2. **Clean status bar** via SystemUI demo mode (re-broadcast before each capture, it can lapse). See
    the `clean-status-bar-capture` note in the agent memory for the full recipe; the key flags:
    `adb shell settings put global sysui_demo_allowed 1` then the demo broadcasts with

--- a/scripts/ci/lib.sh
+++ b/scripts/ci/lib.sh
@@ -1,0 +1,26 @@
+# Shared helpers for the CI scripts. Sourced, never run.
+
+# A release note is the one-line bold headline of each CHANGELOG entry; the full sentences stay in
+# CHANGELOG.md, linked from the release body. Reduces "- **Headline.** detail" to "- Headline." and
+# a "**Sub-header**" line to "#### Sub-header". Both publishers use this, so the shape of a release
+# note is defined once.
+headlines() {
+  sed -E -e 's/^- \*\*([^*]+)\*\*.*/- \1/' -e 's/^\*\*([^*]+)\*\*$/#### \1/'
+}
+
+# Reads back the Reikai commit a published nightly was built from. Every nightly tag points at a
+# stamp commit whose message records it, in the shape nightly.yml writes; keep the two in step.
+# Prints nothing when the release, the stamp or the commit cannot be found.
+nightly_source_commit() {
+  gh api "repos/$PREVIEW_REPO/commits/$1" --jq '.commit.message' 2>/dev/null \
+    | sed -n 's/^\(preview\|nightly\) r[0-9]* (\([0-9a-f]\{7,40\}\))$/\2/p' | head -1
+}
+
+# Newest PUBLISHED nightly tag, empty when the bucket has none. Drafts are excluded on purpose: a
+# dry run leaves one behind and gh lists drafts by default, so the guard would compare against a
+# number nothing was ever released at and skip the next real build. A draft has no tag either, so
+# nightly_source_commit could not resolve it and the notes would fall back to all of [Unreleased].
+latest_nightly_tag() {
+  gh release list --repo "$PREVIEW_REPO" --exclude-drafts --json tagName --limit 1 \
+    --jq 'select(length > 0) | .[0].tagName' || true
+}

--- a/scripts/ci/nightly-guard.sh
+++ b/scripts/ci/nightly-guard.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Refuses a nightly that would publish nothing new. Adapted from Mihon's own preview workflow
+# (mihonapp/mihon-preview 64135ef), which skips a scheduled run when no commits landed since the
+# last release. Reikai has no schedule, so the same idea is pointed at what actually bites here:
+# a tag that does not climb, and a merge that rebuilds a tree already published.
+#
+# Writes skip=true to $GITHUB_OUTPUT when the build should not run. Safe to run locally: without
+# GITHUB_OUTPUT the decision is only printed.
+#
+# Environment: PREVIEW_REPO, GH_TOKEN, EVENT_NAME (github.event_name).
+set -eu
+
+: "${PREVIEW_REPO:?PREVIEW_REPO is required}"
+EVENT_NAME="${EVENT_NAME:-workflow_dispatch}"
+GITHUB_OUTPUT="${GITHUB_OUTPUT:-/dev/null}"
+
+# shellcheck source=scripts/ci/lib.sh
+. "$(dirname "$0")/lib.sh"
+
+# Only ever written when skipping, so the build job's `!= 'true'` does not depend on which of two
+# writes to the same output key wins.
+skip() {
+  echo "skip=true" >> "$GITHUB_OUTPUT"
+  echo "::notice::Skipping nightly: $1"
+  exit 0
+}
+
+# A commit carrying a release tag ships as that release; a nightly of it duplicates it.
+if git tag --points-at HEAD | grep -qE '^v[0-9]'; then
+  skip "$(git tag --points-at HEAD | grep -E '^v[0-9]' | head -1) is a release commit"
+fi
+
+commit_count=$(git rev-list --count HEAD)
+prev_tag=$(latest_nightly_tag)
+if [ -z "$prev_tag" ]; then
+  echo "No previous nightly; building r${commit_count}"
+  exit 0
+fi
+
+# Tags are r<commitCount> and the prune keeps the highest numbers, so a build numbered at or below
+# the newest would be deleted by its own run and ignored by the in-app updater, which compares the
+# tag number against the installed build's commit count.
+prev_count=${prev_tag#r}
+if [ "$commit_count" -le "$prev_count" ]; then
+  skip "r${commit_count} would not climb above ${prev_tag}; is this branch behind the one that built it?"
+fi
+
+# Same content as the last nightly means the same APK. Compare trees, not commits: a merge into
+# another branch is a new commit over an identical tree. A manual run builds anyway, since asking
+# for one is deliberate.
+prev_sha=$(nightly_source_commit "$prev_tag")
+if [ "$EVENT_NAME" = 'push' ] && [ -n "$prev_sha" ] && git cat-file -e "${prev_sha}^{commit}" 2>/dev/null; then
+  if [ "$(git rev-parse 'HEAD^{tree}')" = "$(git rev-parse "${prev_sha}^{tree}")" ]; then
+    skip "tree is identical to ${prev_tag}, so the APK would be the same"
+  fi
+fi
+
+echo "Building r${commit_count}, previous ${prev_tag}"

--- a/scripts/ci/nightly-notes.sh
+++ b/scripts/ci/nightly-notes.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Builds the nightly release body and writes COMMIT_COUNT and RELEASE_BODY to $GITHUB_ENV.
+#
+# Nightly notes are the entries ADDED to CHANGELOG.md's [Unreleased] since the previous nightly, so
+# the running list is not repeated every build. When the changelog was not touched in that range,
+# they fall back to the commit subjects.
+#
+# Environment: PREVIEW_REPO, GH_TOKEN, REPO_URL, HEAD_SHA. Safe to run locally: without GITHUB_ENV
+# the values are printed instead.
+set -eu
+
+: "${PREVIEW_REPO:?PREVIEW_REPO is required}"
+: "${REPO_URL:?REPO_URL is required}"
+: "${HEAD_SHA:?HEAD_SHA is required}"
+GITHUB_ENV="${GITHUB_ENV:-/dev/stdout}"
+
+# shellcheck source=scripts/ci/lib.sh
+. "$(dirname "$0")/lib.sh"
+
+commit_count=$(git rev-list --count HEAD)
+echo "COMMIT_COUNT=$commit_count" >> "$GITHUB_ENV"
+
+# Resolve the previous nightly's source commit by reading it back off that release's stamp commit,
+# which records it. Arithmetic on the commit count cannot do this: counts on main and on a feature
+# branch are unrelated, so a nightly following one built elsewhere would diff against a stranger
+# commit that happened to sit that far back, and the notes would list the whole [Unreleased] section.
+prev_ref=""
+prev_tag=$(latest_nightly_tag)
+if [ -n "$prev_tag" ]; then
+  prev_sha=$(nightly_source_commit "$prev_tag")
+  if [ -n "$prev_sha" ] && git cat-file -e "${prev_sha}^{commit}" 2>/dev/null; then
+    if git merge-base --is-ancestor "$prev_sha" HEAD; then
+      prev_ref="$prev_sha"
+    else
+      # That nightly came off another branch, so the honest base is where the two diverged.
+      prev_ref=$(git merge-base "$prev_sha" HEAD || true)
+    fi
+  fi
+fi
+# A stamp with no recorded commit (or one this clone cannot see) leaves prev_ref empty, and the
+# notes fall back to the whole [Unreleased] section rather than to a guess.
+echo "Previous nightly ${prev_tag:-none}, diffing against ${prev_ref:-nothing}"
+
+parse-changelog CHANGELOG.md Unreleased > /tmp/cur.txt 2>/dev/null || true
+: > /tmp/prev.txt
+if [ -n "$prev_ref" ]; then
+  git show "$prev_ref:CHANGELOG.md" > /tmp/prevchg.md 2>/dev/null \
+    && parse-changelog /tmp/prevchg.md Unreleased > /tmp/prev.txt 2>/dev/null || true
+fi
+
+new_lines=$(grep -vxF -f /tmp/prev.txt /tmp/cur.txt 2>/dev/null | sed '/^[[:space:]]*$/d' || true)
+new_lines=$(printf '%s\n' "$new_lines" | headlines)
+
+{
+  echo "RELEASE_BODY<<__EOF__"
+  if [ -n "$new_lines" ]; then
+    echo "### New since the last nightly"
+    echo ""
+    echo "$new_lines"
+    echo ""
+    # Pin the link to the commit this nightly was built from, not to a branch. A nightly is usually
+    # cut from a feature branch, so blob/main pointed at a changelog that does not contain these
+    # entries, and a branch link would 404 once that branch is merged away.
+    printf '**Full changelog:** %s/blob/%s/CHANGELOG.md\n' "$REPO_URL" "$HEAD_SHA"
+  else
+    commits=""
+    if [ -n "$prev_ref" ]; then
+      commits=$(git log --no-merges --format='- %s' "$prev_ref..HEAD" || true)
+    fi
+    if [ -n "$commits" ]; then
+      echo "### Changes since the last nightly"
+      echo ""
+      echo "$commits"
+    else
+      echo "No changelog or commit changes since the last nightly."
+    fi
+  fi
+  echo "__EOF__"
+} >> "$GITHUB_ENV"

--- a/scripts/ci/package-apks.sh
+++ b/scripts/ci/package-apks.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Renames the built APKs to their published names: reikai[-<abi>]-<tag>.apk.
+#
+# Usage: package-apks.sh <variant> <tag>
+#   package-apks.sh release v0.4.0
+#   package-apks.sh nightly r1234
+#
+# A release also carries the FOSS APK and writes a CHECKSUMS table to $GITHUB_ENV; a nightly ships
+# neither, which is a product difference rather than an oversight.
+set -eu
+
+variant="${1:?usage: package-apks.sh <variant> <tag>}"
+tag="${2:?usage: package-apks.sh <variant> <tag>}"
+GITHUB_ENV="${GITHUB_ENV:-/dev/stdout}"
+
+dir="app/build/outputs/apk/$variant"
+checksums="### Checksums"$'\n\n'"| Variant | SHA-256 |"$'\n'"| ------- | ------- |"
+
+record() {
+  checksums+=$'\n'"| \`$1\` | \`$(sha256sum "$1" | awk '{ print $1 }')\` |"
+}
+
+for abi in universal arm64-v8a armeabi-v7a x86 x86_64; do
+  case "$abi" in
+    universal) out="reikai-${tag}.apk" ;;
+    *)         out="reikai-${abi}-${tag}.apk" ;;
+  esac
+  mv "$dir/app-${abi}-${variant}.apk" "$out"
+  record "$out"
+  echo "$out"
+done
+
+if [ "$variant" = "release" ]; then
+  # FOSS ships universal only, and keeps "-foss" in the name so the in-app updater picks it for
+  # anyone already running that variant.
+  foss_out="reikai-foss-${tag}.apk"
+  mv "app/build/outputs/apk/foss/app-universal-foss.apk" "$foss_out"
+  record "$foss_out"
+  echo "$foss_out"
+
+  {
+    echo "CHECKSUMS<<__EOF__"
+    echo "$checksums"
+    echo "__EOF__"
+  } >> "$GITHUB_ENV"
+fi

--- a/scripts/ci/prune-nightlies.sh
+++ b/scripts/ci/prune-nightlies.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Deletes all but the newest nightlies from the release bucket.
+#
+# Keeps the highest build numbers (tags are r<commitCount>). Sorting by the numeric tag, not
+# createdAt: a history-rewrite force-push can leave every release with the same createdAt, which
+# made an earlier date sort delete the just-published release instead of the oldest. The list limit
+# has to stay above the retention or the slice is always empty and the prune silently stops.
+#
+# Environment: PREVIEW_REPO, GH_TOKEN. KEEP defaults to 365.
+set -eu
+
+: "${PREVIEW_REPO:?PREVIEW_REPO is required}"
+KEEP="${KEEP:-365}"
+LIST_LIMIT=$((KEEP + 135))
+
+gh release list --repo "$PREVIEW_REPO" --exclude-drafts --json tagName --limit "$LIST_LIMIT" \
+  | jq -r --argjson keep "$KEEP" \
+      'sort_by(.tagName | ltrimstr("r") | tonumber) | reverse | .[$keep:] | .[].tagName' \
+  | while read -r tag; do
+      [ -n "$tag" ] && gh release delete "$tag" --repo "$PREVIEW_REPO" --cleanup-tag --yes
+    done

--- a/scripts/ci/release-notes.sh
+++ b/scripts/ci/release-notes.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Builds the stable release body and writes it to $GITHUB_ENV as RELEASE_BODY.
+#
+# Notes come ONLY from the matching [version] section, cut by renaming [Unreleased] to [version].
+# No [Unreleased] fallback, or nightly-only changes would leak into a stable release.
+#
+# Environment: VERSION_TAG, REPO_URL, MESSAGE (optional). Safe to run locally: without GITHUB_ENV
+# the body is printed instead.
+set -eu
+
+: "${VERSION_TAG:?VERSION_TAG is required}"
+: "${REPO_URL:?REPO_URL is required}"
+MESSAGE="${MESSAGE:-}"
+GITHUB_ENV="${GITHUB_ENV:-/dev/stdout}"
+
+# shellcheck source=scripts/ci/lib.sh
+. "$(dirname "$0")/lib.sh"
+
+version="${VERSION_TAG#v}"
+if ! changelog="$(parse-changelog CHANGELOG.md "$version" 2>/dev/null)"; then
+  echo "::error::CHANGELOG.md has no [$version] section. Rename [Unreleased] to [$version] (and add a fresh empty [Unreleased]) before cutting v$version."
+  exit 1
+fi
+
+highlights="$(printf '%s\n' "$changelog" | headlines)"
+# Previous tag (linear main), for a "changes since" compare link. Empty on the first release.
+prev="$(git describe --tags --abbrev=0 "${VERSION_TAG}^" 2>/dev/null || true)"
+
+{
+  echo "RELEASE_BODY<<__EOF__"
+  if [ -n "$MESSAGE" ]; then
+    printf '%s\n\n' "$MESSAGE"
+  fi
+  printf '%s\n\n' "$highlights"
+  printf '**Full changelog:** %s/blob/main/CHANGELOG.md\n' "$REPO_URL"
+  if [ -n "$prev" ]; then
+    printf '**Changes since %s:** %s/compare/%s...%s\n' "$prev" "$REPO_URL" "$prev" "$VERSION_TAG"
+  fi
+  echo "__EOF__"
+} >> "$GITHUB_ENV"

--- a/scripts/ci/stamp-nightly-commit.sh
+++ b/scripts/ci/stamp-nightly-commit.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Creates the commit a nightly release hangs its tag on, and writes STAMP_SHA to $GITHUB_ENV.
+#
+# The releases page orders by the TAG's commit date, not the publish date. Every nightly tag used to
+# point at the release bucket's single LICENSE commit, so that key tied across all of them and GitHub
+# fell back to comparing tag names as strings, which sorts r1350 below r380. Each release now gets
+# its own commit dated at build time, so the primary sort works and the tie-break never runs.
+#
+# The commit reuses the bucket's tree and hangs off it as a sibling, reachable only through its tag,
+# so the bucket's own history stays a single LICENSE commit. Its message records the Reikai commit
+# this nightly was built from, in the exact shape lib.sh's nightly_source_commit parses. Keep those
+# two in step.
+#
+# A dry run reuses the bucket's own head instead of writing a commit. A draft creates no tag, so
+# the stamp would date nothing and would sit there unreachable once the draft is deleted.
+#
+# Environment: PREVIEW_REPO, GH_TOKEN, COMMIT_COUNT, DRY_RUN.
+set -eu
+
+: "${PREVIEW_REPO:?PREVIEW_REPO is required}"
+: "${COMMIT_COUNT:?COMMIT_COUNT is required}"
+GITHUB_ENV="${GITHUB_ENV:-/dev/stdout}"
+
+base=$(gh api "repos/$PREVIEW_REPO/git/ref/heads/main" --jq '.object.sha')
+tree=$(gh api "repos/$PREVIEW_REPO/commits/main" --jq '.commit.tree.sha')
+
+if [ "${DRY_RUN:-false}" = "true" ]; then
+  echo "STAMP_SHA=$base" >> "$GITHUB_ENV"
+  echo "Dry run: hanging the draft off $base rather than writing a stamp commit."
+  exit 0
+fi
+
+bot='{"name":"github-actions[bot]","email":"41898282+github-actions[bot]@users.noreply.github.com"}'
+
+stamp=$(jq -n \
+          --arg m "nightly r${COMMIT_COUNT} ($(git rev-parse HEAD))" \
+          --arg t "$tree" \
+          --arg p "$base" \
+          --arg d "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+          --argjson who "$bot" \
+          '{message:$m, tree:$t, parents:[$p],
+            author:    ($who + {date:$d}),
+            committer: ($who + {date:$d})}' \
+        | gh api "repos/$PREVIEW_REPO/git/commits" --input - --jq '.sha')
+
+echo "STAMP_SHA=$stamp" >> "$GITHUB_ENV"

--- a/scripts/ci/write-firebase-config.sh
+++ b/scripts/ci/write-firebase-config.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Writes the Firebase config that a telemetry build needs. It is never committed (see .gitignore),
+# so it comes from the repo secret; fail loudly rather than let the Google Services plugin guess.
+set -euo pipefail
+
+dest="app/google-services.json"
+
+if [ -z "${GOOGLE_SERVICES_JSON:-}" ]; then
+  echo "::error::GOOGLE_SERVICES_JSON secret is missing; -Pinclude-telemetry cannot build without it."
+  exit 1
+fi
+printf '%s' "$GOOGLE_SERVICES_JSON" > "$dest"
+echo "Wrote $dest."

--- a/scripts/lint-docs-test.sh
+++ b/scripts/lint-docs-test.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Checks that scripts/lint-docs.sh actually rejects what it claims to reject.
+#
+# The rules it enforces are regexes, and a regex that silently stops matching looks exactly like a
+# clean tree. Every case below therefore asserts a failure as well as a pass, which is how the two
+# gaps this file was written for were found: the whole-tree check used to miss "Roadmap 9" in a .kt
+# comment and never looked at .sqm files at all.
+#
+# Run it after touching lint-docs.sh: bash scripts/lint-docs-test.sh
+set -u
+
+lint="$(dirname "$0")/lint-docs.sh"
+work=$(mktemp -d)
+pass=0
+broke=0
+
+# check <name> <expected exit> <command...>
+check() {
+  local name="$1" want="$2"
+  shift 2
+  local got=0
+  "$@" > /dev/null 2>&1 || got=1
+  if [ "$got" = "$want" ]; then
+    echo "  ok    $name"
+    pass=$((pass + 1))
+  else
+    echo "  BROKE $name (wanted exit $want, got $got)"
+    broke=$((broke + 1))
+  fi
+}
+
+fixture() {
+  printf '%b' "$2" > "$work/$1"
+  echo "$work/$1"
+}
+
+clean=$(fixture clean.md 'Nothing to see here.\n')
+
+echo "source-names"
+check "catches a content source"       1 bash "$lint" source-names "$(fixture names.md 'A line about nhentai.\n')" DOC
+check "passes clean prose"             0 bash "$lint" source-names "$clean" DOC
+
+echo "changelog-entries"
+check "catches a missing headline"     1 bash "$lint" changelog-entries "$(fixture bad.md '## [Unreleased]\n\n### Fixes\n\n- No bold headline here.\n')"
+check "passes a self-contained one"    0 bash "$lint" changelog-entries "$(fixture good.md '## [Unreleased]\n\n### Fixes\n\n- **A real headline.** Detail.\n')"
+
+echo "em-dash"
+check "catches an em dash"             1 bash "$lint" em-dash "$(fixture em.md 'text with an em dash \xe2\x80\x94 here\n')" DOC
+check "passes clean punctuation"       0 bash "$lint" em-dash "$clean" DOC
+
+echo "issue-refs"
+check "catches a bare hash ref"        1 bash "$lint" issue-refs "$(fixture ref.md 'see #123 for detail\n')" DOC hint
+check "allows the owner/repo form"     0 bash "$lint" issue-refs "$(fixture ref2.md 'see mihonapp/mihon#123\n')" DOC hint
+
+echo "codenames"
+codename() { printf '%b' "$1" | bash "$lint" codenames --stdin; }
+check "catches a phase marker"         1 codename '+// Phase 3 of the port\n'
+check "catches a roadmap number"       1 codename '// see Roadmap 9\n'
+check "catches one in a .sqm comment"  1 codename '-- overlay (P6). detail\n'
+check "spares R8, the code shrinker"   0 codename '// R8 strips the signature\n'
+check "spares a colon-led step"        0 codename '// Step 1: read the file\n'
+check "passes an ordinary comment"     0 codename '// nothing to flag here\n'
+
+echo "manifest-rows"
+check "catches a resurrected file"     1 bash "$lint" manifest-rows "$(fixture man.md '| app/src/main/java/eu/kanade/tachiyomi/App.kt | mihon | nowhere/Absent.kt |\n')"
+check "catches a manifest with no rows" 1 bash "$lint" manifest-rows "$(fixture man2.md 'no rows at all\n')"
+
+for f in "$work"/*.md; do rm -f "$f"; done
+rmdir "$work" 2> /dev/null || true
+
+echo
+echo "passed=$pass broken=$broke"
+[ "$broke" -eq 0 ]

--- a/scripts/lint-docs.sh
+++ b/scripts/lint-docs.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# The doc and comment conventions from .claude/rules/workflow.md ("Public-facing naming", "After
+# completing any code change") and code-quality.md, in one place.
+#
+# Both .githooks/pre-commit and .github/workflows/docs-lint.yml call this, because they enforce the
+# same rules on different content: the hook checks what you staged, CI checks the whole tree. Each
+# subcommand therefore takes the content to scan, and the caller decides what that is.
+#
+# Usage:
+#   lint-docs.sh source-names <file> <label>     no content-source names
+#   lint-docs.sh changelog-entries <file>        [Unreleased] headline shape and length cap
+#   lint-docs.sh em-dash <file> <label>          no em dash
+#   lint-docs.sh issue-refs <file> <label> <hint>   no bare #N
+#   lint-docs.sh codenames                       plan/roadmap codenames, candidate lines on stdin
+#   lint-docs.sh manifest-rows <file>            every off-path row still describes reality
+#
+# Exits non-zero when a check fails. Under GitHub Actions the heading is emitted as ::error:: so it
+# lands as an annotation; locally it is printed plainly.
+set -u
+
+# Content-source names (adult and mainstream) that must be genericized or use an approved shorthand
+# (EH / ExH / MD / CMK) in the public-facing docs. Trackers (MangaUpdates, Shikimori, AniList, ...)
+# are NOT sources and stay allowed. Extend this list as new sources get named in the repo.
+DENY='e-hentai|ehentai|exhentai|nhentai|pururin|8muses|hentaifox|asmhentai|koharu|schalenetwork|mangadex|comick'
+
+# A bare '#N' auto-links to a Reikai issue. A '#' + digits not preceded by an alphanumeric; the
+# owner/repo#N form is fine.
+BARE_ISSUE_REF='(^|[^A-Za-z0-9])#[0-9]'
+
+# A comment line: //, a block-comment opener, a KDoc *-line, or a SQL -- line.
+COMMENT_LINE='(//|/\*|^\+?[[:space:]]*\*|^\+?[[:space:]]*--)'
+
+# Plan and roadmap codenames, which rot as the plan moves on. Caught: Phase N, the P<phase> / P5 S5
+# shorthand, Y<n> Yokai-era refs, R<n> roadmap refs, Active #N, and in-words "Roadmap N" /
+# "Roadmap:" (the bare document name ROADMAP.md stays allowed). Spared below the line: R8 (the code
+# shrinker, so R uses [0-79]) and M3 (Material 3, M is not matched).
+CODENAME='(Phase[[:space:]]*[0-9]|Active[[:space:]]*#[0-9]|\b[PY][0-9][a-z]?\b|\bR[0-79][a-z]?\b|\b[Ss]tep[[:space:]]*[0-9]|[Rr]oadmap[[:space:]]*(#?[0-9]|:))'
+
+# A colon-led algorithm step ("Step 1:") is fine; a plan-style "Step 3" is not. The step match is
+# case-insensitive because a lower-case "step 2" reached main once. Two Kotlin range shapes quoted
+# in comments are spared too: "2..20 step 6" and a fractional "step 0.5".
+CODENAME_SPARED='(\b[Ss]tep[[:space:]]*[0-9]:|[0-9]\.\.[0-9]+[[:space:]]+step[[:space:]]|[Ss]tep[[:space:]]*[0-9]+\.[0-9])'
+
+report() {
+  if [ -n "${GITHUB_ACTIONS:-}" ]; then
+    echo "::error::$1"
+  else
+    echo "$1"
+  fi
+  shift
+  printf '%s\n' "$@"
+}
+
+cmd="${1:?usage: lint-docs.sh <check> [args]}"
+shift
+
+case "$cmd" in
+  source-names)
+    file="${1:?file}"; label="${2:?label}"
+    if hits=$(grep -inE "$DENY" "$file"); then
+      report "$label names a content source; genericize it or use an approved shorthand (EH / ExH / MD / CMK). See Public-facing naming." "$hits"
+      exit 1
+    fi
+    ;;
+
+  changelog-entries)
+    file="${1:?file}"
+    issues=$(awk '
+      /^## \[Unreleased\]/ { u=1; next }
+      /^## \[/             { u=0 }
+      !u                  { next }
+      /^### /             { sec=$0; sub(/^### /,"",sec); next }
+      /^\*\*/             { next }
+      /^- / {
+        if (length($0) > 320)
+          print "  - over the length cap (>320 chars); trim to a bold headline + one sentence:\n    " $0
+        if (sec != "Other" && $0 !~ /^- \*\*[^*]+[.!?]\*\*/)
+          print "  - needs a self-contained bold headline ending in . ! or ? (Other is exempt):\n    " $0
+      }
+    ' "$file")
+    if [ -n "$issues" ]; then
+      report "CHANGELOG [Unreleased] entry issues:" "$issues"
+      exit 1
+    fi
+    ;;
+
+  em-dash)
+    file="${1:?file}"; label="${2:?label}"
+    if hits=$(grep -n '—' "$file"); then
+      report "$label contains an em dash; use commas, parentheses, periods or colons." "$hits"
+      exit 1
+    fi
+    ;;
+
+  issue-refs)
+    file="${1:?file}"; label="${2:?label}"; hint="${3:?hint}"
+    if hits=$(grep -nE "$BARE_ISSUE_REF" "$file"); then
+      report "$label has a bare '#N', which auto-links to a Reikai issue; use $hint." "$hits"
+      exit 1
+    fi
+    ;;
+
+  codenames)
+    # --stdin reads candidate lines (the hook pipes the lines a commit adds); --tree scans every
+    # tracked source file. Both apply the same three patterns, which is the point of sharing this.
+    #
+    # A leading '+' from a diff is tolerated. In --tree mode the patterns go to git grep rather than
+    # to a pipe, so they match file content and never the "path:line:" prefix git prints after.
+    mode="${1:---stdin}"
+    if [ "$mode" = "--tree" ]; then
+      hits=$(git grep -nE -e "$COMMENT_LINE" --and -e "$CODENAME" --and --not -e "$CODENAME_SPARED" \
+        -- '*.kt' '*.kts' '*.sq' '*.sqm' || true)
+    else
+      hits=$(grep -E "$COMMENT_LINE" | grep -E "$CODENAME" | grep -vE "$CODENAME_SPARED" || true)
+    fi
+    if [ -n "$hits" ]; then
+      report "a code comment carries a plan/roadmap codename marker (Phase N, P5 S5, Y3, R3, Active #N, Roadmap N, plan Step N); state the durable fact instead. See code-quality.md." "$hits"
+      exit 1
+    fi
+    ;;
+
+  manifest-rows)
+    # The manifest only works if every row is real and no listed file comes back. Both failures are
+    # otherwise silent: a resurrected file gives two implementations of one surface, and a row
+    # pointing nowhere protects nothing.
+    file="${1:?file}"
+    # A tree with no manifest has nothing to protect, which is the case on a branch cut before the
+    # delete-and-manifest policy existed. Absent is not a violation; an empty one is, below.
+    if [ ! -f "$file" ]; then
+      echo "off-path manifest: $file does not exist here, nothing to check."
+      exit 0
+    fi
+    fail=0
+    # Data rows look like `| <path> | <upstream> | <replacement> |`, the shape off-path-check.ps1 parses.
+    rows=$(grep -E '^\|[[:space:]]*[a-z0-9-]+/' "$file" || true)
+    if [ -z "$rows" ]; then
+      report "off-path manifest has no machine-readable rows, so the sync check would silently pass."
+      exit 1
+    fi
+    while IFS='|' read -r _ path _ repl _; do
+      path=$(echo "$path" | tr -d ' ')
+      repl=$(echo "$repl" | tr -d ' ')
+      [ -z "$path" ] && continue
+      if [ -e "$path" ]; then
+        report "off-path manifest: '$path' is listed as deleted but exists in the tree." \
+          "  Either it was resurrected (delete it, its twin renders the surface), or it is live again" \
+          "  (drop its manifest row and say why in the commit)."
+        fail=1
+      fi
+      [ -z "$repl" ] && continue
+      found=0
+      for root in app/src/main/java domain/src/main/java data/src/main/java core/common/src/main/kotlin ""; do
+        [ -e "${root:+$root/}$repl" ] && found=1 && break
+      done
+      if [ "$found" -eq 0 ]; then
+        report "off-path manifest: replacement '$repl' does not exist, so the row protects nothing."
+        fail=1
+      fi
+    done <<< "$rows"
+    [ "$fail" -eq 0 ] || exit 1
+    ;;
+
+  *)
+    echo "lint-docs.sh: unknown check '$cmd'" >&2
+    exit 2
+    ;;
+esac

--- a/source-local/src/androidMain/kotlin/tachiyomi/source/local/LocalSource.kt
+++ b/source-local/src/androidMain/kotlin/tachiyomi/source/local/LocalSource.kt
@@ -21,6 +21,7 @@ import mihon.core.archive.archiveReader
 import mihon.core.archive.epubReader
 import nl.adaptivity.xmlutil.core.AndroidXmlReader
 import nl.adaptivity.xmlutil.serialization.XML
+import tachiyomi.core.common.Constants
 import tachiyomi.core.common.i18n.stringResource
 import tachiyomi.core.common.storage.extension
 import tachiyomi.core.common.storage.nameWithoutExtension
@@ -373,7 +374,7 @@ actual class LocalSource(
 
     companion object {
         const val ID = 0L
-        const val HELP_URL = "https://mihon.app/docs/guides/local-source/"
+        const val HELP_URL = "${Constants.URL_DOCS}/guides/local-source/" // RK: Reikai's docs
 
         private val LATEST_THRESHOLD = 7.days.inWholeMilliseconds
     }

--- a/telemetry/src/firebase/kotlin/mihon/telemetry/TelemetryConfig.kt
+++ b/telemetry/src/firebase/kotlin/mihon/telemetry/TelemetryConfig.kt
@@ -14,7 +14,7 @@ object TelemetryConfig {
 
     fun init(context: Context) {
         // To stop forks/test builds from polluting our data
-        if (!context.isMihonProductionApp()) return
+        if (!context.isReikaiProductionApp()) return // RK: Reikai's own gate, see the island below
 
         // Check if Google Play Services is available before initializing Firebase
         if (!isGooglePlayServicesAvailable(context)) {
@@ -50,15 +50,20 @@ object TelemetryConfig {
         crashlytics?.isCrashlyticsCollectionEnabled = enabled
     }
 
-    private fun Context.isMihonProductionApp(): Boolean {
-        if (packageName !in MIHON_PACKAGES) return false
+    // RK --> Reikai's own packages and signing certificate, replacing Mihon's.
+    private fun Context.isReikaiProductionApp(): Boolean {
+        if (packageName !in REIKAI_PACKAGES) return false
 
         return packageManager.getPackageInfo(packageName, SignatureFlags)
             .getCertificateFingerprints()
-            .any { it == MIHON_CERTIFICATE_FINGERPRINT }
+            .any { it == REIKAI_CERTIFICATE_FINGERPRINT }
     }
 }
 
-private val MIHON_PACKAGES = hashSetOf("app.mihon", "app.mihon.debug")
-private const val MIHON_CERTIFICATE_FINGERPRINT =
-    "9A:DD:65:5A:78:E9:6C:4E:C7:A5:3E:F8:9D:CC:B5:57:CB:5D:76:74:89:FA:C5:E7:85:D6:71:A5:A7:5D:4D:A2"
+// The stable and preview packages only: the local dev build is deliberately absent, so it never
+// reports even when signed with the release key, which a local signing config makes the default.
+// Matched exactly, so a package rename silently stops all reporting until this list moves with it.
+private val REIKAI_PACKAGES = hashSetOf("app.reikai", "app.reikai.debug")
+private const val REIKAI_CERTIFICATE_FINGERPRINT =
+    "D0:E2:7C:7C:43:A6:BE:B1:66:BB:18:83:19:EE:4A:03:4F:7B:F0:A3:9B:CC:03:EC:E6:49:5C:E0:8F:5D:D6:EC"
+// RK <--


### PR DESCRIPTION
Reikai has shipped under `eu.kanade.tachiyomi` since the Yokai era, which is Tachiyomi's app id rather than its own. This cuts 0.3.2 under `app.reikai`, named the way the other Mihon forks name theirs.

Android identifies an app by that id, so this release installs beside an existing Reikai instead of replacing it. The release note is written as migration instructions, because the in-app update prompt shows it before anyone downloads.

## What a user sees

- The update installs as a second app; the old one keeps working until it is removed.
- Downloads, the local source and existing backups are found again once the same storage folder is picked, because they live outside the app.
- A backup carries the library, and tracker logins too when sensitive settings are ticked. Custom covers are the only thing it cannot bring across.
- Every help link in the app now opens Reikai's own documentation rather than Mihon's, including the "Getting started guide" on the empty Library screen.

## Under the hood

- Release ships as plain `app.reikai` with no suffix, matching upstream; preview, FOSS, benchmark and debug take upstream's suffixes, so debug becomes `.dev`. This drops two RK islands from the build file. The preview slot also stops colliding with Tachiyomi's own preview package.
- The namespace stays `eu.kanade.tachiyomi`, which Mihon shares, so installed extensions resolve unchanged.
- Crash reporting is gated on an exact package and certificate match. This branch still carried Mihon's gate, which would have shipped reporting that silently collected nothing.
- `release.yml` is brought forward from the 0.4.0 branch: main's version predates it by twenty-odd commits and built without telemetry and without the FOSS APK. Its shell now lives in `scripts/ci`, runnable before a release rather than discovered at tag-push time.
- `versionCode` climbs to 185 so later releases upgrade this one in place.

## Verification

`./gradlew test`, a minified `assembleRelease`, and `assembleRelease -Pinclude-telemetry` all pass, the last uploading its Crashlytics mapping, which only happens once the Firebase config matches the new id. Every shipping variant's merged manifest reports the right package. The release APK installs and runs on the emulator: onboarding completes, the Library renders, Crashlytics initialises for `app.reikai`, and the storage picker finds the existing folder. Every documentation URL and anchor was checked against the live site.

`release.yml` itself is exercised by the tag, so it is the one part still unproven.